### PR TITLE
Rename dateCreated into date

### DIFF
--- a/src/_includes/post-header.njk
+++ b/src/_includes/post-header.njk
@@ -13,7 +13,7 @@
     {% endif %}
   </div>
   {# Only show these metadata if there is a date #}
-  {% if date %}
+  {% if (date) or (dateModified) %}
   <p class="label divide-list center">
     {% if subtitle %}<span>{{ subtitle }}</span>{% endif %}
     {% if author %}<span>{{ author }}</span>{% endif %}

--- a/src/_includes/post-header.njk
+++ b/src/_includes/post-header.njk
@@ -18,11 +18,10 @@
     {% if subtitle %}<span>{{ subtitle }}</span>{% endif %}
     {% if author %}<span>{{ author }}</span>{% endif %}
     {# Prioritize dateModifited over date #}
-    {# dateModified needs to be formatted as it was manually added #}
     {% if dateModified %}
       <span class="sr-only">Updated on</span><time datetime="{{ dateModified | formatDate }}" class="dt-updated">{{ dateModified | formatDate }}</time>
     {% elif date %}
-      <span class="sr-only">Published on</span><time datetime="{{ date }}" class="dt-published">{{ date }}</time>
+      <span class="sr-only">Published on</span><time datetime="{{ date | formatDate }}" class="dt-published">{{ date | formatDate }}</time>
     {% endif %}
     {% if duration %}<span>{{ duration }}&nbsp;min</span>{% endif %}
     {% if tags %} 

--- a/src/_includes/post-header.njk
+++ b/src/_includes/post-header.njk
@@ -12,16 +12,17 @@
     ></div>
     {% endif %}
   </div>
-  {# Only show subtitles, dates, etc. in post-header if the page includes dateCreated #}
-  {% if (dateCreated) or (dateModified) %}
+  {# Only show these metadata if there is a date #}
+  {% if date %}
   <p class="label divide-list center">
     {% if subtitle %}<span>{{ subtitle }}</span>{% endif %}
     {% if author %}<span>{{ author }}</span>{% endif %}
-    {# Prioritize dateModifited over dateCreated #}
+    {# Prioritize dateModifited over date #}
+    {# dateModified needs to be formatted as it was manually added #}
     {% if dateModified %}
       <span class="sr-only">Updated on</span><time datetime="{{ dateModified | formatDate }}" class="dt-updated">{{ dateModified | formatDate }}</time>
-    {%- else -%}
-      <span class="sr-only">Published on</span><time datetime="{{ dateCreated | formatDate }}" class="dt-published">{{ dateCreated | formatDate }}</time>
+    {% elif date %}
+      <span class="sr-only">Published on</span><time datetime="{{ date }}" class="dt-published">{{ date }}</time>
     {% endif %}
     {% if duration %}<span>{{ duration }}&nbsp;min</span>{% endif %}
     {% if tags %} 

--- a/src/colophon.njk
+++ b/src/colophon.njk
@@ -13,8 +13,7 @@ icon: /img/meta/drawing-tool.svg
     <h2>Behind the scenes</h2>
   <ul>
     <li>
-      I built this website with the static site generator
-      <a href="https://github.com/11ty/eleventy">Eleventy</a>.
+      I built this website with the Eleventy static site generator.
     </li>
     <li>It is hosted on Cloudflare.</li>
     <li>

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -21,14 +21,17 @@
     <link>{{ metadata.url }}</link>
     <atom:link href="{{ permalink | absoluteUrl(metadata.url) }}" rel="self" type="application/rss+xml" />
     <description>{{ metadata.subtitle }}</description>
+    {% set sortedPostList = collections.posts | reverse %}
+    <lastBuildDate>{{ sortedPostList[0].date | dateToRfc822 }}</lastBuildDate>
+    <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+    <generator>https://github.com/11ty/eleventy-plugin-rss</generator>
     <language>{{ metadata.language }}</language>
-    {%- for post in collections.posts | reverse %}
-    {%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
+    {%- for post in sortedPostList.slice(0,20) %} {%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
     <item>
       <title>{{ post.data.title }}</title>
       <link>{{ absolutePostUrl }}</link>
       <description>{{ post.templateContent | replace("{end-key}","⊙") | htmlToAbsoluteUrls(absolutePostUrl) }}</description>
-      <pubDate>{{ post.data.dateCreated | dateToRfc822 }}</pubDate>
+      <pubDate>{{ post.date | dateToRfc822 }}</pubDate>
       <dc:creator>{{ metadata.author.name }}</dc:creator>
       <guid>{{ absolutePostUrl }}</guid>
     </item>

--- a/src/learning.njk
+++ b/src/learning.njk
@@ -35,7 +35,7 @@ icon: /img/meta/drawing-star.svg
   <article data-tag="{{ post.data.tags }}" id="{{ post.fileSlug }}">
     <div class="post-header">
       <h2>{{ post.data.title }}</h2>
-      <span class="label"><time class="dt-duration" datetime="{{ post.data.dateCreated }}">{{ post.data.dateCreated }} </time>/ 
+      <span class="label"><time class="dt-duration" datetime="{{ post.date | formatDate }}">{{ post.date | formatDate}} </time>/ 
         {% set comma = joiner() %}
         {% for tag in post.data.tags | filterTags %}
         {{ comma() }} <a href="/{{ post.data.directory }}/?q={{ tag }}">{{ tag }}</a>

--- a/src/learning/astro-1-stars-or-planets.md
+++ b/src/learning/astro-1-stars-or-planets.md
@@ -1,6 +1,6 @@
 ---
 title: "Stars or planets?"
-dateCreated: "2023-11-15"
+date: "2023-11-15"
 tags: ["astronomy"]
 sourceUrl: "https://archive.org/details/fieldguidetostar00menz_0/mode/1up"
 ---

--- a/src/learning/cooking-1-colloids-from-mayonnaise-to-hairspray.md
+++ b/src/learning/cooking-1-colloids-from-mayonnaise-to-hairspray.md
@@ -1,6 +1,6 @@
 ---
 title: "Colloids: From mayonnaise to hairspray"
-dateCreated: "2023-09-30"
+date: "2023-09-30"
 tags: ["cooking"]
 sourceUrl: "https://en.wikipedia.org/wiki/Colloid"
 ---

--- a/src/learning/cooking-2-food-pigments-keep-green-food-green.md
+++ b/src/learning/cooking-2-food-pigments-keep-green-food-green.md
@@ -1,6 +1,6 @@
 ---
 title: "Food pigments: Keep green food green"
-dateCreated: "2023-09-30"
+date: "2023-09-30"
 tags: ["cooking"]
 sourceUrl: "https://foodcrumbles.com/how-to-keep-green-food-green-controlling-chlorophyll/"
 ---

--- a/src/learning/cooking-3-food-pigments-purple-blue-or-red-blueberries.md
+++ b/src/learning/cooking-3-food-pigments-purple-blue-or-red-blueberries.md
@@ -1,6 +1,6 @@
 ---
 title: "Food pigments: Purple, blue or red blueberries"
-dateCreated: "2023-09-30"
+date: "2023-09-30"
 tags: ["cooking"]
 sourceUrl: "https://niksharmacooks.com/the-flavor-equation/"
 ---

--- a/src/learning/cooking-4-food-pigments-red-beets.md
+++ b/src/learning/cooking-4-food-pigments-red-beets.md
@@ -1,6 +1,6 @@
 ---
 title: "Food pigments: Red beets"
-dateCreated: "2023-09-30"
+date: "2023-09-30"
 tags: ["cooking"]
 sourceUrl: "https://niksharmacooks.com/the-flavor-equation/"
 ---

--- a/src/learning/cooking-5-how-to-cut-open-a-pomegranate.md
+++ b/src/learning/cooking-5-how-to-cut-open-a-pomegranate.md
@@ -1,6 +1,6 @@
 ---
 title: "How to cut open a pomegranate"
-dateCreated: "2023-10-15"
+date: "2023-10-15"
 tags: ["cooking"]
 sourceUrl: ""
 ---

--- a/src/learning/data-viz-1-data-visualization-handbook.md
+++ b/src/learning/data-viz-1-data-visualization-handbook.md
@@ -1,6 +1,6 @@
 ---
 title: "Data viz: Data visualization handbook"
-dateCreated: "2022-05-05"
+date: "2022-05-05"
 tags: ["miscellaneous"]
 sourceUrl: "https://www.datavizhandbook.com/"
 ---

--- a/src/learning/data-viz-2-introduction.md
+++ b/src/learning/data-viz-2-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: "Data viz: Introduction"
-dateCreated: "2022-05-05"
+date: "2022-05-05"
 tags: ["miscellaneous"]
 sourceUrl: "https://www.datavizhandbook.com/"
 ---

--- a/src/learning/data-viz-3-general-principles-of-visualization-design.md
+++ b/src/learning/data-viz-3-general-principles-of-visualization-design.md
@@ -1,6 +1,6 @@
 ---
 title: "Data viz: General principles of visualization design"
-dateCreated: "2022-05-05"
+date: "2022-05-05"
 tags: ["miscellaneous"]
 sourceUrl: "https://www.datavizhandbook.com/"
 ---

--- a/src/learning/geologie-1-les-familles-de-roches.md
+++ b/src/learning/geologie-1-les-familles-de-roches.md
@@ -1,6 +1,6 @@
 ---
 title: "Géologie: Les familles de roches"
-dateCreated: "2023-12-09"
+date: "2023-12-09"
 tags: ["miscellaneous"]
 sourceUrl: "https://www.unilim.fr/musee_geologique_de_plein_air/les-roches-presentees-2/il-existe-quatre-grandes-familles-de-roches/"
 ---

--- a/src/learning/geologie-2-les-roches-sedimentaires.md
+++ b/src/learning/geologie-2-les-roches-sedimentaires.md
@@ -1,6 +1,6 @@
 ---
 title: "Géologie : Les roches sédimentaires"
-dateCreated: "2023-12-09"
+date: "2023-12-09"
 tags: ["miscellaneous"]
 sourceUrl: "https://www.unilim.fr/musee_geologique_de_plein_air/les-roches-presentees-2/les-roches-sedimentaires/"
 ---

--- a/src/learning/grande-voie-1-le-materiel.md
+++ b/src/learning/grande-voie-1-le-materiel.md
@@ -1,6 +1,6 @@
 ---
 title: "Grande-voie: Le matériel"
-dateCreated: "2023-10-01"
+date: "2023-10-01"
 tags: ["climbing"]
 ---
 

--- a/src/learning/grande-voie-2-les-manips-au-relai.md
+++ b/src/learning/grande-voie-2-les-manips-au-relai.md
@@ -1,6 +1,6 @@
 ---
 title: "Grande-voie: Les manips au relai"
-dateCreated: "2023-10-01"
+date: "2023-10-01"
 tags: ["climbing"]
 sourceUrl: "https://www.youtube.com/watch?v=Pm60skIwN4s"
 ---

--- a/src/learning/making-solid-shampoo.md
+++ b/src/learning/making-solid-shampoo.md
@@ -1,6 +1,6 @@
 ---
 title: "Making solid shampoo"
-dateCreated: "2023-10-16"
+date: "2023-10-16"
 tags: ["diy"]
 sourceUrl: ""
 ---

--- a/src/learning/middle-dot.md
+++ b/src/learning/middle-dot.md
@@ -1,6 +1,6 @@
 ---
 title: "Middle dot"
-dateCreated: "2023-10-21"
+date: "2023-10-21"
 tags: ["miscellaneous"]
 sourceUrl: ""
 ---

--- a/src/learning/nuages-les-bases.md
+++ b/src/learning/nuages-les-bases.md
@@ -1,6 +1,6 @@
 ---
 title: "Nuages: Les bases"
-dateCreated: "2023-11-27"
+date: "2023-11-27"
 tags: ["miscellaneous"]
 sourceUrl: "https://www.youtube.com/watch?v=QytVOC1VVOM"
 ---

--- a/src/learning/russian-1-duolingoing.md
+++ b/src/learning/russian-1-duolingoing.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: Duolingoing"
-dateCreated: "2023-09-29"
+date: "2023-09-29"
 tags: ["language"]
 ---
 

--- a/src/learning/russian-2-to-be-or-not-to-be.md
+++ b/src/learning/russian-2-to-be-or-not-to-be.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: To be or not to be"
-dateCreated: "2023-09-29"
+date: "2023-09-29"
 tags: ["language"]
 ---
 

--- a/src/learning/russian-3-cases-the-basics.md
+++ b/src/learning/russian-3-cases-the-basics.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: Cases, the basics"
-dateCreated: "2023-09-29"
+date: "2023-09-29"
 tags: ["language"]
 ---
 

--- a/src/learning/russian-4-to-have.md
+++ b/src/learning/russian-4-to-have.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: To have"
-dateCreated: "2023-09-29"
+date: "2023-09-29"
 tags: ["language"]
 ---
 

--- a/src/learning/russian-5-you-you-you.md
+++ b/src/learning/russian-5-you-you-you.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: You, you, you"
-dateCreated: "2023-09-29"
+date: "2023-09-29"
 tags: ["language"]
 ---
 

--- a/src/learning/russian-6-about-names.md
+++ b/src/learning/russian-6-about-names.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: About names"
-dateCreated: "2023-09-29"
+date: "2023-09-29"
 tags: ["language"]
 ---
 

--- a/src/learning/russian-7-frequent-words.md
+++ b/src/learning/russian-7-frequent-words.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: Frequent words"
-dateCreated: "2023-10-02"
+date: "2023-10-02"
 tags: ["language"]
 ---
 

--- a/src/learning/russian-8-hello.md
+++ b/src/learning/russian-8-hello.md
@@ -1,6 +1,6 @@
 ---
 title: "Russian: Hello"
-dateCreated: "2023-10-02"
+date: "2023-10-02"
 tags: ["language"]
 ---
 

--- a/src/learning/stop-motion-first-steps.md
+++ b/src/learning/stop-motion-first-steps.md
@@ -1,6 +1,6 @@
 ---
 title: "Stop motion: First steps"
-dateCreated: "2022-02-13"
+date: "2022-02-13"
 tags: ["miscellaneous"]
 ---
 

--- a/src/media/12-angry-men.md
+++ b/src/media/12-angry-men.md
@@ -2,7 +2,7 @@
 title: "12 Angry Men"
 author: ["Reginald Rose"]
 cover: "https://image.tmdb.org/t/p/w1280/ppd84D2i9W8jXmsyInGyihiSyqz.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1957"
 ---

--- a/src/media/1984.md
+++ b/src/media/1984.md
@@ -2,7 +2,7 @@
 title: "12 Angry Men"
 author: ["George Orwell"]
 cover: "https://covers.openlibrary.org/b/id/8579190-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1949"
 ---

--- a/src/media/a-gentleman-in-moscow.md
+++ b/src/media/a-gentleman-in-moscow.md
@@ -2,7 +2,7 @@
 title: "A Gentleman in Moscow"
 author: ["Amor Towles"]
 cover: "https://covers.openlibrary.org/b/id/11326818-L.jpg"
-dateCreated: "2022-05-01"
+date: "2022-05-01"
 tags: ["book"]
 year: "2016"
 ---

--- a/src/media/adieu-boheme.md
+++ b/src/media/adieu-boheme.md
@@ -2,7 +2,7 @@
 title: "Adieu Bohème"
 author: ["Jeanne Frenkel"]
 cover: "https://image.tmdb.org/t/p/w1280/qXQPjOZW6lMJMWlO94ki2jc1o9B.jpg"
-dateCreated: "2022-01-01"
+date: "2022-01-01"
 tags: ["movie"]
 year: "2017"
 ---

--- a/src/media/aftersun.md
+++ b/src/media/aftersun.md
@@ -2,7 +2,7 @@
 title: "Aftersun"
 author: "Charlotte Wells"
 cover: "https://image.tmdb.org/t/p/w1280/jeXmhP2zbUkREMRqFOYIwQOk49T.jpg"
-dateCreated: "2022-12-01"
+date: "2022-12-01"
 tags: ["movie"]
 year: "2022"
 ---

--- a/src/media/ali-and-nino.md
+++ b/src/media/ali-and-nino.md
@@ -2,7 +2,7 @@
 title: "Ali and Nino"
 author: ["Kurban Said"]
 cover: "https://covers.openlibrary.org/b/id/6927843-L.jpg"
-dateCreated: "2024-02-20"
+date: "2024-02-20"
 tags: ["book"]
 year: "1937"
 ---

--- a/src/media/amelie.md
+++ b/src/media/amelie.md
@@ -2,7 +2,7 @@
 title: "Amélie"
 author: ["Jean-Pierre Jeunet"]
 cover: "https://image.tmdb.org/t/p/w1280/vZ9NhNbQQ3yhtiC5sbhpy5KTXns.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2001"
 ---

--- a/src/media/and-then-there-were-none.md
+++ b/src/media/and-then-there-were-none.md
@@ -2,7 +2,7 @@
 title: "And Then There Were None"
 author: ["Agatha Christie"]
 cover: "https://covers.openlibrary.org/b/id/6393980-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1939"
 ---

--- a/src/media/basara.md
+++ b/src/media/basara.md
@@ -2,7 +2,7 @@
 title: "Basara series"
 author: ["Yumi Tamura"]
 cover: "https://covers.openlibrary.org/b/id/9260371-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2003"
 ---

--- a/src/media/broken-earth-trilogy.md
+++ b/src/media/broken-earth-trilogy.md
@@ -2,7 +2,7 @@
 title: "Broken Earth trilogy"
 author: ["N. K. Jemisin"]
 cover: "https://covers.openlibrary.org/b/id/9158524-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2015"
 ---

--- a/src/media/cant-we-talk-about-something-more-pleasant.md
+++ b/src/media/cant-we-talk-about-something-more-pleasant.md
@@ -2,7 +2,7 @@
 title: "Can't We Talk About Something More Pleasant?"
 author: ["Roz Chast"]
 cover: "https://covers.openlibrary.org/b/id/7312632-L.jpg"
-dateCreated: "2023-07-31"
+date: "2023-07-31"
 tags: ["book"]
 year: "2014"
 ---

--- a/src/media/captain-fantastic.md
+++ b/src/media/captain-fantastic.md
@@ -2,7 +2,7 @@
 title: "Captain Fantastic"
 author: ["Matt Ross"]
 cover: "https://image.tmdb.org/t/p/w1280/2sFME73GaD8UsUxPUKe60cPdLif.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2016"
 ---

--- a/src/media/chroniques-birmanes.md
+++ b/src/media/chroniques-birmanes.md
@@ -2,7 +2,7 @@
 title: "Chroniques birmanes"
 author: ["Guy Delisle"]
 cover: "https://covers.openlibrary.org/b/id/6666112-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2009"
 ---

--- a/src/media/circe.md
+++ b/src/media/circe.md
@@ -2,7 +2,7 @@
 title: "Circe"
 author: ["Madeline Miller"]
 cover: "https://covers.openlibrary.org/b/id/10618670-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2018"
 ---

--- a/src/media/coraline.md
+++ b/src/media/coraline.md
@@ -2,7 +2,7 @@
 title: "Coraline"
 author: ["Henry Selick"]
 cover: "https://image.tmdb.org/t/p/w1280/7Hgiro8MGcfrHFi1ulgpmXaJhGV.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2009"
 ---

--- a/src/media/django-unchained.md
+++ b/src/media/django-unchained.md
@@ -2,7 +2,7 @@
 title: "Django Unchained"
 author: ["Quentin Tarantino"]
 cover: "https://image.tmdb.org/t/p/w1280/mgp4F0jQfixmgQtrn7QfrswRZK4.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2012"
 ---

--- a/src/media/do-the-right-thing.md
+++ b/src/media/do-the-right-thing.md
@@ -2,7 +2,7 @@
 title: "Do the Right Thing"
 author: ["Spike Lee"]
 cover: "https://image.tmdb.org/t/p/w1280/oAeLEyWYObkLmYbRnPQAKBUAQw3.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1989"
 ---

--- a/src/media/dune.md
+++ b/src/media/dune.md
@@ -2,7 +2,7 @@
 title: "Dune"
 author: ["Eric Roth"]
 cover: "https://image.tmdb.org/t/p/w1280/8hoD5BQuUV9dDecAbiyVIxLjzZ9.jpg"
-dateCreated: "2021-12-01"
+date: "2021-12-01"
 tags: ["movie"]
 year: "2021"
 ---

--- a/src/media/everything-everywhere-all-at-once.md
+++ b/src/media/everything-everywhere-all-at-once.md
@@ -2,7 +2,7 @@
 title: "Everything Everywhere All At Once"
 author: ["Daniel Scheinert", "Daniel Kwan"]
 cover: "https://image.tmdb.org/t/p/w1280/w3LxiVYdWWRvEVdn5RYq6jIqkb1.jpg"
-dateCreated: "2022-12-01"
+date: "2022-12-01"
 tags: ["movie"]
 year: "2022"
 ---

--- a/src/media/ex-machina.md
+++ b/src/media/ex-machina.md
@@ -2,7 +2,7 @@
 title: "Ex Machina"
 author: ["Alex Garland"]
 cover: "https://image.tmdb.org/t/p/w1280/dmJW8IAKHKxFNiUnoDR7JfsK7Rp.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2015"
 ---

--- a/src/media/fight-club.md
+++ b/src/media/fight-club.md
@@ -2,7 +2,7 @@
 title: "Fight Club"
 author: ["David Fincher"]
 cover: "https://image.tmdb.org/t/p/w1280/rtEZ3JH8RjFS1b8z2pwyh9YI9WX.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1999"
 ---

--- a/src/media/freakonomics.md
+++ b/src/media/freakonomics.md
@@ -2,7 +2,7 @@
 title: "Freakonomics"
 author: ["Steven D. Levitt", "Stephen J. Dubner"]
 cover: "https://covers.openlibrary.org/b/id/39479-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2005"
 ---

--- a/src/media/free-solo.md
+++ b/src/media/free-solo.md
@@ -2,7 +2,7 @@
 title: "Free Solo"
 author: ["Elizabeth Chai Vasarhelyi", "Jimmy Chin"]
 cover: "https://image.tmdb.org/t/p/w1280/v4QfYZMACODlWul9doN9RxE99ag.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2018"
 ---

--- a/src/media/get-out.md
+++ b/src/media/get-out.md
@@ -2,7 +2,7 @@
 title: "Get Out"
 author: ["Jordan Peele"]
 cover: "https://image.tmdb.org/t/p/w1280/DaDh4SXcJHHDvdMCpng2M95r8s.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2017"
 ---

--- a/src/media/gone-girl.md
+++ b/src/media/gone-girl.md
@@ -2,7 +2,7 @@
 title: "Gone Girl"
 author: ["Gillian Flynn"]
 cover: "https://covers.openlibrary.org/b/id/11567795-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2011"
 ---

--- a/src/media/guillermo-del-toros-pinocchio.md
+++ b/src/media/guillermo-del-toros-pinocchio.md
@@ -2,7 +2,7 @@
 title: "Guillermo del Toro's Pinocchio"
 author: ["Guillermo del Toro"]
 cover: "https://image.tmdb.org/t/p/w1280/fwT6twArrihDBhunn5urP0qCQVD.jpg"
-dateCreated: "2023-01-01"
+date: "2023-01-01"
 tags: ["movie"]
 year: "2022"
 ---

--- a/src/media/half-of-a-yellow-sun.md
+++ b/src/media/half-of-a-yellow-sun.md
@@ -2,7 +2,7 @@
 title: "Half of a Yellow Sun"
 author: ["Chimamanda Ngozi Adichie"]
 cover: "https://covers.openlibrary.org/b/id/11325154-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2006"
 ---

--- a/src/media/harry-potter-series.md
+++ b/src/media/harry-potter-series.md
@@ -2,7 +2,7 @@
 title: "Harry Potter series"
 author: ["J. K. Rowling"]
 cover: "https://covers.openlibrary.org/b/id/12902949-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1998"
 ---

--- a/src/media/her.md
+++ b/src/media/her.md
@@ -2,7 +2,7 @@
 title: "Her"
 author: ["Spike Jonze"]
 cover: "https://image.tmdb.org/t/p/w1280/eCOtqtfvn7mxGl6nfmq4b1exJRc.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2013"
 ---

--- a/src/media/his-dark-materials-series.md
+++ b/src/media/his-dark-materials-series.md
@@ -2,7 +2,7 @@
 title: "His Dark Materials series"
 author: ["Philip Pullman"]
 cover: "https://covers.openlibrary.org/b/id/14345468-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1995"
 ---

--- a/src/media/hocus-pocus.md
+++ b/src/media/hocus-pocus.md
@@ -2,7 +2,7 @@
 title: "Hocus Pocus"
 author: ["Kenny Ortega"]
 cover: "https://image.tmdb.org/t/p/w1280/9Y5AEhIuMuONTXXylAmg4sgRLPB.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1993"
 ---

--- a/src/media/howls-moving-castle.md
+++ b/src/media/howls-moving-castle.md
@@ -2,7 +2,7 @@
 title: "Howl's Moving Castle"
 author: ["Hayao Miyazaki"]
 cover: "https://image.tmdb.org/t/p/w1280/2KvuvaIBDxrafatQHX4hoj4FcI6.jpg"
-dateCreated: "2023-06-29"
+date: "2023-06-29"
 tags: ["movie"]
 year: "2004"
 ---

--- a/src/media/hunt-for-the-wilderpeople.md
+++ b/src/media/hunt-for-the-wilderpeople.md
@@ -2,7 +2,7 @@
 title: "Hunt for the Wilderpeople"
 author: ["Taika Waititi"]
 cover: "https://image.tmdb.org/t/p/w1280/QKVexLBGxjLYfgV2WBH90VzAHt.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2016"
 ---

--- a/src/media/in-the-mood-for-love.md
+++ b/src/media/in-the-mood-for-love.md
@@ -2,7 +2,7 @@
 title: "In the Mood for Love"
 author: ["Wong Kar-wai"]
 cover: "https://image.tmdb.org/t/p/w1280/iYypPT4bhqXfq1b6EnmxvRt6b2Y.jpg"
-dateCreated: "2023-09-20"
+date: "2023-09-20"
 tags: ["movie"]
 year: "2000"
 ---

--- a/src/media/inception.md
+++ b/src/media/inception.md
@@ -2,7 +2,7 @@
 title: "Inception"
 author: ["Christopher Nolan"]
 cover: "https://image.tmdb.org/t/p/w1280/ljsZTbVsrQSqZgWeep2B1QiDKuh.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2010"
 ---

--- a/src/media/interstellar.md
+++ b/src/media/interstellar.md
@@ -2,7 +2,7 @@
 title: "Interstellar"
 author: ["Christopher Nolan"]
 cover: "https://image.tmdb.org/t/p/w1280/mS4EvhsrT0SQZOlWrQEzWI5KiUa.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2014"
 ---

--- a/src/media/joker.md
+++ b/src/media/joker.md
@@ -2,7 +2,7 @@
 title: "Joker"
 author: ["Todd Phillips"]
 cover: "https://image.tmdb.org/t/p/w1280/udDclJoHjfjb8Ekgsd4FDteOkCU.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2019"
 ---

--- a/src/media/jumanji.md
+++ b/src/media/jumanji.md
@@ -2,7 +2,7 @@
 title: "Jumanji"
 author: ["Jake Kasdan"]
 cover: "https://image.tmdb.org/t/p/w1280/pSgXKPU5h6U89ipF7HBYajvYt7j.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2017"
 ---

--- a/src/media/kill-bill.md
+++ b/src/media/kill-bill.md
@@ -2,7 +2,7 @@
 title: "Kill Bill"
 author: ["Quentin Tarantino"]
 cover: "https://image.tmdb.org/t/p/w1280/zomX76Pf3nUaTzRBk5BveLk1QPu.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2003"
 ---

--- a/src/media/kirikou-and-the-sorceress.md
+++ b/src/media/kirikou-and-the-sorceress.md
@@ -2,7 +2,7 @@
 title: "Kirikou and the Sorceress"
 author: ["Michel Ocelot"]
 cover: "https://image.tmdb.org/t/p/w1280/oYM8Gz1JYLYpokgVjiBfIWdr4Ns.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1998"
 ---

--- a/src/media/kubo-and-the-two-strings.md
+++ b/src/media/kubo-and-the-two-strings.md
@@ -2,7 +2,7 @@
 title: "Kubo and the Two Strings"
 author: ["Travis Knight"]
 cover: "https://image.tmdb.org/t/p/w1280/la6QA9tk4Foq8OBH2Dyh5dTcw6H.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2016"
 ---

--- a/src/media/la-horde-de-contrevent.md
+++ b/src/media/la-horde-de-contrevent.md
@@ -2,7 +2,7 @@
 title: "La Horde de Contrevent"
 author: ["Alain Damasio"]
 cover: "https://covers.openlibrary.org/b/id/6670450-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2007"
 ---

--- a/src/media/la-la-land.md
+++ b/src/media/la-la-land.md
@@ -2,7 +2,7 @@
 title: "La La Land"
 author: ["Damien Chazelle"]
 cover: "https://image.tmdb.org/t/p/w1280/uDO8zWDhfWwoFdKS4fzkUJt0Rf0.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2016"
 ---

--- a/src/media/la-quete-dewilan-series.md
+++ b/src/media/la-quete-dewilan-series.md
@@ -2,7 +2,7 @@
 title: "La Quête d'Ewilan series"
 author: ["Pierre Bottero"]
 cover: "https://covers.openlibrary.org/b/id/10864878-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2006"
 ---

--- a/src/media/le-grand-mechant-renard.md
+++ b/src/media/le-grand-mechant-renard.md
@@ -2,7 +2,7 @@
 title: "Le Grand Méchant Renard"
 author: ["Benjamin Renner"]
 cover: "https://covers.openlibrary.org/b/id/10867922-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2015"
 ---

--- a/src/media/lechappee-belle.md
+++ b/src/media/lechappee-belle.md
@@ -2,7 +2,7 @@
 title: "L'échappée belle"
 author: ["Anna Gavalda"]
 cover: "https://covers.openlibrary.org/b/id/11330877-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2001"
 ---

--- a/src/media/life-of-pi-book.md
+++ b/src/media/life-of-pi-book.md
@@ -2,7 +2,7 @@
 title: "Life of Pi"
 author: ["Yann Martel"]
 cover: "https://covers.openlibrary.org/b/id/6526427-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2001"
 ---

--- a/src/media/life-of-pi.md
+++ b/src/media/life-of-pi.md
@@ -2,7 +2,7 @@
 title: "Life of Pi"
 author: ["Ang Lee"]
 cover: "https://image.tmdb.org/t/p/w1280/mYDKm9HxImm8PRru3KbkHAe1cmk.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2012"
 ---

--- a/src/media/loki.md
+++ b/src/media/loki.md
@@ -2,7 +2,7 @@
 title: "Loki"
 author: ["Michael Waldron"]
 cover: "https://image.tmdb.org/t/p/w1280/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg"
-dateCreated: "2021-12-01"
+date: "2021-12-01"
 tags: ["tv series"]
 year: "2021"
 ---

--- a/src/media/lord-of-the-flies.md
+++ b/src/media/lord-of-the-flies.md
@@ -2,7 +2,7 @@
 title: "Lord of the Flies"
 author: ["William Golding"]
 cover: "https://covers.openlibrary.org/b/id/12723924-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1954"
 ---

--- a/src/media/maniac.md
+++ b/src/media/maniac.md
@@ -2,7 +2,7 @@
 title: "Maniac"
 author: ["Cary Joji Fukunaga", "Patrick Somerville"]
 cover: "https://image.tmdb.org/t/p/w1280/kCNl4QPstAqChFD0NnLpbDFG8ul.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["tv series"]
 year: "2018"
 ---

--- a/src/media/mary-poppins.md
+++ b/src/media/mary-poppins.md
@@ -2,7 +2,7 @@
 title: "Mary Poppins"
 author: ["Robert Stevenson"]
 cover: "https://image.tmdb.org/t/p/w1280/mrHTMQ6bIUQeo2WLD4KF8fYW4Nl.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1964"
 ---

--- a/src/media/media.11tydata.js
+++ b/src/media/media.11tydata.js
@@ -2,8 +2,8 @@
 // Source docs: https://www.11ty.dev/docs/data-computed/
 module.exports = {
   eleventyComputed: {
-    // Generate post creation year automatically from dateCreated frontmatter
-    yearCreated: (data) => new Date(data.dateCreated).getFullYear(),
+    // Generate post creation year automatically from date frontmatter
+    yearCreated: (data) => new Date(data.date).getFullYear(),
   },
   layout: "layout/post.njk",
   tags: "media",

--- a/src/media/memento.md
+++ b/src/media/memento.md
@@ -2,7 +2,7 @@
 title: "Memento"
 author: ["Christopher Nolan"]
 cover: "https://image.tmdb.org/t/p/w1280/yuNs09hvpHVU1cBTCAk9zxsL2oW.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2000"
 ---

--- a/src/media/memoirs-of-a-geisha.md
+++ b/src/media/memoirs-of-a-geisha.md
@@ -2,7 +2,7 @@
 title: "Memoirs of a Geisha"
 author: ["Arthur Golden"]
 cover: "https://covers.openlibrary.org/b/id/225330-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1997"
 ---

--- a/src/media/metaphysique-des-tubes.md
+++ b/src/media/metaphysique-des-tubes.md
@@ -2,7 +2,7 @@
 title: "Métaphysique des Tubes"
 author: ["Amélie Nothomb"]
 cover: "https://covers.openlibrary.org/b/id/977702-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2002"
 ---

--- a/src/media/midsommar.md
+++ b/src/media/midsommar.md
@@ -2,7 +2,7 @@
 title: "Midsommar"
 author: ["Ari Aster"]
 cover: "https://image.tmdb.org/t/p/w1280/7LEI8ulZzO5gy9Ww2NVCrKmHeDZ.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2019"
 ---

--- a/src/media/moonrise-kingdom.md
+++ b/src/media/moonrise-kingdom.md
@@ -2,7 +2,7 @@
 title: "Moonrise Kingdom"
 author: ["Wes Anderson"]
 cover: "https://image.tmdb.org/t/p/w1280/xrziXRHRQ7c7YLIehgSJY8GQBsx.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2012"
 ---

--- a/src/media/mulholland-drive.md
+++ b/src/media/mulholland-drive.md
@@ -2,7 +2,7 @@
 title: "Mulholland Drive"
 author: ["David Lynch"]
 cover: "https://image.tmdb.org/t/p/w1280/czJ71FeOCyDhpXp0WtqYIyZf3kZ.jpg"
-dateCreated: "2024-05-12"
+date: "2024-05-12"
 tags: ["movie"]
 year: "2001"
 ---

--- a/src/media/mushi-shi.md
+++ b/src/media/mushi-shi.md
@@ -2,7 +2,7 @@
 title: "Mushi-Shi"
 author: ["Hiroshi Nagahama"]
 cover: "https://image.tmdb.org/t/p/w1280/6hcZcirYerZzLJbl658xn1KHr6d.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["tv series"]
 year: "2005"
 ---

--- a/src/media/nage-libre.md
+++ b/src/media/nage-libre.md
@@ -2,7 +2,7 @@
 title: "Nage libre"
 author: ["Sébastien Chrisostome"]
 cover: "https://covers.openlibrary.org/b/id/14534483-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2008"
 ---

--- a/src/media/never-let-me-go.md
+++ b/src/media/never-let-me-go.md
@@ -2,7 +2,7 @@
 title: "Never Let Me Go"
 author: ["Kazuo Ishiguro"]
 cover: "https://covers.openlibrary.org/b/id/11685000-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2005"
 ---

--- a/src/media/orphan-black.md
+++ b/src/media/orphan-black.md
@@ -2,7 +2,7 @@
 title: "Orphan black"
 author: ["John Fawcett", "Graeme Manson"]
 cover: "https://image.tmdb.org/t/p/w1280/tjFYkWMafg71sihs1aa7IDx17aS.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["tv series"]
 year: "2013"
 ---

--- a/src/media/our-flag-means-death.md
+++ b/src/media/our-flag-means-death.md
@@ -2,7 +2,7 @@
 title: "Our flag means death"
 author: ["David Jenkins"]
 cover: "https://image.tmdb.org/t/p/w1280/mP9OYUoZWod61G8gnsZ5TX1qft.jpg"
-dateCreated: "2022-09-01"
+date: "2022-09-01"
 tags: ["tv series"]
 year: "2022"
 ---

--- a/src/media/parasite.md
+++ b/src/media/parasite.md
@@ -2,7 +2,7 @@
 title: "Parasite"
 author: ["Bong Joon-ho"]
 cover: "https://image.tmdb.org/t/p/w1280/tNJB14t2lqZ9L4oyEKoN6DT2ou8.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2019"
 ---

--- a/src/media/perfect-days.md
+++ b/src/media/perfect-days.md
@@ -2,7 +2,7 @@
 title: "Perfect Days"
 author: ["Wim Wenders"]
 cover: "https://image.tmdb.org/t/p/w1280/tvUHVSTJV9ITON3oyHaWp7oaAc8.jpg"
-dateCreated: "2023-12-03"
+date: "2023-12-03"
 tags: ["movie"]
 year: "2023"
 ---

--- a/src/media/reservation-dogs.md
+++ b/src/media/reservation-dogs.md
@@ -2,7 +2,7 @@
 title: "Reservation Dogs"
 author: ["Taika Waititi", "Sterlin Harjo"]
 cover: "https://image.tmdb.org/t/p/w1280/ApzExFmLWANlp0BJUHmtDZRKyCA.jpg"
-dateCreated: "2022-12-01"
+date: "2022-12-01"
 tags: ["tv series"]
 year: "2021"
 ---

--- a/src/media/schindlers-list.md
+++ b/src/media/schindlers-list.md
@@ -2,7 +2,7 @@
 title: "Schindler's List"
 author: ["Steven Spielberg"]
 cover: "https://image.tmdb.org/t/p/w1280/sF1U4EUQS8YHUYjNl3pMGNIQyr0.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1993"
 ---

--- a/src/media/sherlock.md
+++ b/src/media/sherlock.md
@@ -2,7 +2,7 @@
 title: "Sherlock"
 author: ["Mark Gatiss"]
 cover: "https://image.tmdb.org/t/p/w1280/cIfGAkpvWD2zxHrXzhv3uptYbyV.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["tv series"]
 year: "2010"
 ---

--- a/src/media/shutter-island.md
+++ b/src/media/shutter-island.md
@@ -2,7 +2,7 @@
 title: "Shutter Island"
 author: ["Martin Scorsese"]
 cover: "https://image.tmdb.org/t/p/w1280/4GDy0PHYX3VRXUtwK5ysFbg3kEx.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2010"
 ---

--- a/src/media/soul.md
+++ b/src/media/soul.md
@@ -2,7 +2,7 @@
 title: "Soul"
 author: ["Pete Docter"]
 cover: "https://image.tmdb.org/t/p/w1280/hm58Jw4Lw8OIeECIq5qyPYhAeRJ.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2020"
 ---

--- a/src/media/spotlight.md
+++ b/src/media/spotlight.md
@@ -2,7 +2,7 @@
 title: "Spotlight"
 author: ["Tom McCarthy"]
 cover: "https://image.tmdb.org/t/p/w1280/gWkgMnIsd8Od7iyhEEKL5G4Qq6J.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2015"
 ---

--- a/src/media/still-life.md
+++ b/src/media/still-life.md
@@ -2,7 +2,7 @@
 title: "Still Life"
 author: ["Louise Penny"]
 cover: "https://covers.openlibrary.org/b/id/180980-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2006"
 ---

--- a/src/media/stories-of-your-life-and-others.md
+++ b/src/media/stories-of-your-life-and-others.md
@@ -2,7 +2,7 @@
 title: "Stories of Your Life and Others"
 author: ["Ted Chiang"]
 cover: "https://covers.openlibrary.org/b/id/13367980-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2010"
 ---

--- a/src/media/stranger-things.md
+++ b/src/media/stranger-things.md
@@ -2,7 +2,7 @@
 title: "Stranger Things"
 author: ["Matt Duffer", "Ross Duffer"]
 cover: "https://image.tmdb.org/t/p/w1280/pi8WsJtGKxuJHdp0m1W2wq7IvxW.jpg"
-dateCreated: "2022-01-01"
+date: "2022-01-01"
 tags: ["tv series"]
 year: "2016"
 ---

--- a/src/media/subaru-series.md
+++ b/src/media/subaru-series.md
@@ -2,7 +2,7 @@
 title: "Subaru series"
 author: ["Masahito Soda"]
 cover: "https://covers.openlibrary.org/b/id/10971827-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2006"
 ---

--- a/src/media/the-artist.md
+++ b/src/media/the-artist.md
@@ -2,7 +2,7 @@
 title: "The Artist"
 author: ["Michel Hazanavicius"]
 cover: "https://image.tmdb.org/t/p/w1280/z68py0ZqPgeacGPG54AGVRbNBS7.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2011"
 ---

--- a/src/media/the-beach.md
+++ b/src/media/the-beach.md
@@ -2,7 +2,7 @@
 title: "The Beach"
 author: ["Alex Garland"]
 cover: "https://covers.openlibrary.org/b/id/823949-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1996"
 ---

--- a/src/media/the-godfather.md
+++ b/src/media/the-godfather.md
@@ -2,7 +2,7 @@
 title: "The Godfather"
 author: ["Francis Ford Coppola"]
 cover: "https://image.tmdb.org/t/p/w1280/3bhkrj58Vtu7enYsRolD1fZdja1.jpg"
-dateCreated: "2023-01-01"
+date: "2023-01-01"
 tags: ["movie"]
 year: "1972"
 ---

--- a/src/media/the-great-escape.md
+++ b/src/media/the-great-escape.md
@@ -2,7 +2,7 @@
 title: "The Great Escape"
 author: ["John Sturges"]
 cover: "https://image.tmdb.org/t/p/w1280/gBH4H8UMFxl139HaLz6lRuvsel8.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1963"
 ---

--- a/src/media/the-great-gatsby.md
+++ b/src/media/the-great-gatsby.md
@@ -2,7 +2,7 @@
 title: "The Great Gatsby"
 author: ["F. Scott Fitzgerald"]
 cover: "https://covers.openlibrary.org/b/id/8458088-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1920"
 ---

--- a/src/media/the-guernsey-literary-and-potato-peel-pie-society.md
+++ b/src/media/the-guernsey-literary-and-potato-peel-pie-society.md
@@ -2,7 +2,7 @@
 title: "The Guernsey Literary and Potato Peel Pie Society"
 author: ["Mary Ann Shaffer", "Annie Barrows"]
 cover: "https://covers.openlibrary.org/b/id/10159827-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2008"
 ---

--- a/src/media/the-handmaiden.md
+++ b/src/media/the-handmaiden.md
@@ -2,7 +2,7 @@
 title: "The Handmaiden"
 author: ["Park Chan-wook"]
 cover: "https://image.tmdb.org/t/p/w1280/oZrLMir5kxqErMoLQTG9gP4NCyk.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2016"
 ---

--- a/src/media/the-handmaids-tale.md
+++ b/src/media/the-handmaids-tale.md
@@ -2,7 +2,7 @@
 title: "The Handmaid's Tale"
 author: ["Margaret Atwood"]
 cover: "https://covers.openlibrary.org/b/id/14339093-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "1985"
 ---

--- a/src/media/the-martian.md
+++ b/src/media/the-martian.md
@@ -2,7 +2,7 @@
 title: "The Martian"
 author: ["Andy Weir"]
 cover: "https://covers.openlibrary.org/b/id/11447888-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2011"
 ---

--- a/src/media/the-matrix.md
+++ b/src/media/the-matrix.md
@@ -2,7 +2,7 @@
 title: "The Matrix"
 author: ["Lana Wachowski", "Lilly Wachowski"]
 cover: "https://image.tmdb.org/t/p/w1280/dXNAPwY7VrqMAo51EKhhCJfaGb5.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1999"
 ---

--- a/src/media/the-murderbot-diaries.md
+++ b/src/media/the-murderbot-diaries.md
@@ -2,7 +2,7 @@
 title: "The Murderbot Diaries"
 author: "Martha Wells"
 cover: "https://covers.openlibrary.org/b/id/8478857-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2017"
 ---

--- a/src/media/the-night-circus.md
+++ b/src/media/the-night-circus.md
@@ -2,7 +2,7 @@
 title: "The Night Circus"
 author: ["Erin Morgenstern"]
 cover: "https://covers.openlibrary.org/b/id/8750520-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2011"
 ---

--- a/src/media/the-omnivores-dilemma.md
+++ b/src/media/the-omnivores-dilemma.md
@@ -2,7 +2,7 @@
 title: "The Omnivore's Dilemma"
 author: ["Michael Pollan"]
 cover: "https://covers.openlibrary.org/b/id/8596711-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2006"
 ---

--- a/src/media/the-others.md
+++ b/src/media/the-others.md
@@ -2,7 +2,7 @@
 title: "The Others"
 author: ["Alejandro Amenábar"]
 cover: "https://image.tmdb.org/t/p/w1280/AdTFzlJmQ3rTtTpoyS9rqU17qN7.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2001"
 ---

--- a/src/media/the-pianist.md
+++ b/src/media/the-pianist.md
@@ -2,7 +2,7 @@
 title: "The Pianist"
 author: ["Roman Polanski"]
 cover: "https://image.tmdb.org/t/p/w1280/2hFvxCCWrTmCYwfy7yum0GKRi3Y.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2002"
 ---

--- a/src/media/the-power-of-the-dog.md
+++ b/src/media/the-power-of-the-dog.md
@@ -2,7 +2,7 @@
 title: "The Power of the Dog"
 author: ["Jane Campion"]
 cover: "https://image.tmdb.org/t/p/w1280/epb8WAquLI1S38HWLaHwSdKvxHm.jpg"
-dateCreated: "2021-12-01"
+date: "2021-12-01"
 tags: ["movie"]
 year: "2021"
 ---

--- a/src/media/the-prestige.md
+++ b/src/media/the-prestige.md
@@ -2,7 +2,7 @@
 title: "The Prestige"
 author: ["Christopher Nolan"]
 cover: "https://image.tmdb.org/t/p/w1280/bdN3gXuIZYaJP7ftKK2sU0nPtEA.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2006"
 ---

--- a/src/media/the-queens-gambit.md
+++ b/src/media/the-queens-gambit.md
@@ -2,7 +2,7 @@
 title: "The Queen's Gambit"
 author: ["Scott Frank", "Allan Scott"]
 cover: "https://image.tmdb.org/t/p/w1280/9sKYp7GthiqlFWLWE4J62vGciH2.jpg"
-dateCreated: "2023-01-01"
+date: "2023-01-01"
 tags: ["tv series"]
 year: "2020"
 ---

--- a/src/media/the-shawshank-redemption.md
+++ b/src/media/the-shawshank-redemption.md
@@ -2,7 +2,7 @@
 title: "The Shawshank Redemption"
 author: ["Frank Darabont"]
 cover: "https://image.tmdb.org/t/p/w1280/lyQBXzOQSuE59IsHyhrp0qIiPAz.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1994"
 ---

--- a/src/media/the-thirteenth-tale.md
+++ b/src/media/the-thirteenth-tale.md
@@ -2,7 +2,7 @@
 title: "The Thirteenth Tale"
 author: ["Diane Setterfield"]
 cover: "https://covers.openlibrary.org/b/id/1384980-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2006"
 ---

--- a/src/media/the-three-body-problem.md
+++ b/src/media/the-three-body-problem.md
@@ -2,7 +2,7 @@
 title: "The Three-Body Problem trilogy"
 author: ["Cixin Liu"]
 cover: "https://covers.openlibrary.org/b/id/9157544-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2008"
 ---

--- a/src/media/the-truman-show.md
+++ b/src/media/the-truman-show.md
@@ -2,7 +2,7 @@
 title: "The Truman Show"
 author: ["Peter Weir"]
 cover: "https://image.tmdb.org/t/p/w1280/vuza0WqY239yBXOadKlGwJsZJFE.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1998"
 ---

--- a/src/media/the-wonderful-story-of-henry-sugar.md
+++ b/src/media/the-wonderful-story-of-henry-sugar.md
@@ -2,7 +2,7 @@
 title: "The Wonderful Story of Henry Sugar"
 author: ["Wes Anderson"]
 cover: "https://image.tmdb.org/t/p/w1280/fGqiDeb1KCVH5a1y9Nd8SfpZmvm.jpg"
-dateCreated: "2023-10-05"
+date: "2023-10-05"
 tags: ["movie"]
 year: "2023"
 ---

--- a/src/media/three-billboards-outside-ebbing-missouri.md
+++ b/src/media/three-billboards-outside-ebbing-missouri.md
@@ -2,7 +2,7 @@
 title: "Three Billboards Outside Ebbing, Missouri"
 author: ["Martin McDonagh"]
 cover: "https://image.tmdb.org/t/p/w1280/pZRhqJj0DBy4ghB7g6pU7MGHsWJ.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2017"
 ---

--- a/src/media/triangle-of-sadness.md
+++ b/src/media/triangle-of-sadness.md
@@ -2,7 +2,7 @@
 title: "Triangle of Sadness"
 author: ["Ruben Östlund"]
 cover: "https://image.tmdb.org/t/p/w1280/k9eLozCgCed5FGTSdHu0bBElAV8.jpg"
-dateCreated: "2022-12-01"
+date: "2022-12-01"
 tags: ["movie"]
 year: "2022"
 ---

--- a/src/media/wall-e.md
+++ b/src/media/wall-e.md
@@ -2,7 +2,7 @@
 title: "WALL·E"
 author: ["Andrew Stanton"]
 cover: "https://image.tmdb.org/t/p/w1280/hbhFnRzzg6ZDmm8YAmxBnQpQIPh.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2008"
 ---

--- a/src/media/wandavision.md
+++ b/src/media/wandavision.md
@@ -2,7 +2,7 @@
 title: "WandaVision"
 author: ["Jac Schaeffer"]
 cover: "https://image.tmdb.org/t/p/w1280/glKDfE6btIRcVB5zrjspRIs4r52.jpg"
-dateCreated: "2021-12-01"
+date: "2021-12-01"
 tags: ["tv series"]
 year: "2021"
 ---

--- a/src/media/what-we-do-in-the-shadows.md
+++ b/src/media/what-we-do-in-the-shadows.md
@@ -2,7 +2,7 @@
 title: "What We Do in the Shadows"
 author: "Taika Waititi"
 cover: "https://image.tmdb.org/t/p/w1280/32QNWU2RoB7El5m2cjo3TnmvUxJ.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2014"
 ---

--- a/src/media/where-the-mountain-meets-the-moon.md
+++ b/src/media/where-the-mountain-meets-the-moon.md
@@ -2,7 +2,7 @@
 title: "Where the mountain meets the moon"
 author: ["Grace Lin"]
 cover: "https://covers.openlibrary.org/b/id/14561336-L.jpg"
-dateCreated: "2024-03-13"
+date: "2024-03-13"
 tags: ["book"]
 year: "2009"
 ---

--- a/src/media/wizard-of-oz.md
+++ b/src/media/wizard-of-oz.md
@@ -2,7 +2,7 @@
 title: "Wizard of Oz"
 author: ["Victor Fleming"]
 cover: "https://image.tmdb.org/t/p/w1280/bSA6DbAC5gdkaooU164lQUX6rVs.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "1939"
 ---

--- a/src/media/world-of-tomorrow.md
+++ b/src/media/world-of-tomorrow.md
@@ -2,7 +2,7 @@
 title: "World of Tomorrow"
 author: ["Don Hertzfeldt"]
 cover: "https://image.tmdb.org/t/p/w1280/5s7DSOek7Bk2CvcG1zX01bJzJ0x.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["movie"]
 year: "2015"
 ---

--- a/src/media/years-and-years.md
+++ b/src/media/years-and-years.md
@@ -2,7 +2,7 @@
 title: "Years and Years"
 author: ["Simon Cellan Jones", "Lisa Mulcahy"]
 cover: "https://image.tmdb.org/t/p/w1280/u1FBsyMH9Tx7K5yzMnJsYRvNEKQ.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["tv series"]
 year: "2019"
 ---

--- a/src/media/yotsuba-series.md
+++ b/src/media/yotsuba-series.md
@@ -2,7 +2,7 @@
 title: "Yotsuba&! series"
 author: ["Kiyohiko Azuma"]
 cover: "https://covers.openlibrary.org/b/id/14353841-L.jpg"
-dateCreated: "2021-01-01"
+date: "2021-01-01"
 tags: ["book"]
 year: "2018"
 ---

--- a/src/now.md
+++ b/src/now.md
@@ -2,7 +2,7 @@
 layout: "layout/post.njk"
 title: "Now"
 subtitle: "Chilling mode"
-dateCreated: "2024-04-30"
+date: "2024-04-30"
 tags: ["now"]
 icon: /img/meta/drawing-location.svg
 directory: "posts"

--- a/src/posts.njk
+++ b/src/posts.njk
@@ -30,6 +30,7 @@ icon: /img/meta/drawing-face.svg
 {% for yearCreated, posts in collections.posts | groupby("data.yearCreated") | dictsort | reverse %}
   <h2>{{ yearCreated }}</h2>
   <ul class="nobullet post-rows">
+    {# 11ty sorts collections by date by default, just need to reverse to display as LIFO #}
     {% for post in posts | reverse %}
     <li data-tag="{{ post.data.tags }}">
       <time class="label dt-duration" datetime="{{ post.date }}">{{ post.date | formatDate("short") }}</time>

--- a/src/posts.njk
+++ b/src/posts.njk
@@ -32,7 +32,7 @@ icon: /img/meta/drawing-face.svg
   <ul class="nobullet post-rows">
     {% for post in posts | reverse %}
     <li data-tag="{{ post.data.tags }}">
-      <time class="label dt-duration" datetime="{{ post.data.dateCreated }}">{{ post.data.dateCreated | formatDate("short") }}</time>
+      <time class="label dt-duration" datetime="{{ post.date }}">{{ post.date | formatDate("short") }}</time>
       <span class="details">
         <a href="{{ post.url }}">{{ post.data.title }}</a>
         <span class="subtle">{{ post.data.subtitle }}</span>

--- a/src/posts/10-beginners-mistakes-to-avoid-when-designing-for-print.md
+++ b/src/posts/10-beginners-mistakes-to-avoid-when-designing-for-print.md
@@ -1,7 +1,7 @@
 ---
 title: "10 beginners mistakes to avoid when designing for print"
 subtitle: "I made them too and will probably make them again"
-dateCreated: "2019-05-27"
+date: "2019-05-27"
 tags: ["creative"]
 ---
 

--- a/src/posts/10-on-obsessions.md
+++ b/src/posts/10-on-obsessions.md
@@ -1,7 +1,7 @@
 ---
 title: "#10 On obsessions"
 subtitle: "Update #10"
-dateCreated: "2021-01-10"
+date: "2021-01-10"
 tags: ["update"]
 ---
 

--- a/src/posts/11-habits-in-the-oven.md
+++ b/src/posts/11-habits-in-the-oven.md
@@ -1,7 +1,7 @@
 ---
 title: "#11 Habits in the oven"
 subtitle: "Update #11"
-dateCreated: "2021-01-17"
+date: "2021-01-17"
 tags: ["update"]
 ---
 

--- a/src/posts/12-culinary-experiments.md
+++ b/src/posts/12-culinary-experiments.md
@@ -1,7 +1,7 @@
 ---
 title: "#12 Culinary experiments"
 subtitle: "Update #12"
-dateCreated: "2021-01-23"
+date: "2021-01-23"
 tags: ["update"]
 ---
 

--- a/src/posts/13-holiday-at-home.md
+++ b/src/posts/13-holiday-at-home.md
@@ -1,7 +1,7 @@
 ---
 title: "#13 Holiday at home"
 subtitle: "Update #13"
-dateCreated: "2021-01-30"
+date: "2021-01-30"
 tags: ["update"]
 ---
 

--- a/src/posts/14-books-books-books.md
+++ b/src/posts/14-books-books-books.md
@@ -1,7 +1,7 @@
 ---
 title: "#14 Books, books, books"
 subtitle: "Update #14"
-dateCreated: "2021-02-07"
+date: "2021-02-07"
 tags: ["update"]
 ---
 

--- a/src/posts/15-walk-on-the-frozen-canal.md
+++ b/src/posts/15-walk-on-the-frozen-canal.md
@@ -1,7 +1,7 @@
 ---
 title: "#15 Walk on the frozen canal"
 subtitle: "Update #15"
-dateCreated: "2021-02-14"
+date: "2021-02-14"
 tags: ["update"]
 ---
 

--- a/src/posts/16-sunbathing-on-planet-earth.md
+++ b/src/posts/16-sunbathing-on-planet-earth.md
@@ -1,7 +1,7 @@
 ---
 title: "#16 Sunbathing on planet Earth"
 subtitle: "Update #16"
-dateCreated: "2021-02-22"
+date: "2021-02-22"
 tags: ["update"]
 ---
 

--- a/src/posts/17-back-on-tracks.md
+++ b/src/posts/17-back-on-tracks.md
@@ -1,7 +1,7 @@
 ---
 title: "#17 Back on tracks"
 subtitle: "Update #17"
-dateCreated: "2022-11-18"
+date: "2022-11-18"
 tags: ["update"]
 ---
 

--- a/src/posts/18-friendsgiving-and-dnd.md
+++ b/src/posts/18-friendsgiving-and-dnd.md
@@ -1,7 +1,7 @@
 ---
 title: "#18 Friendsgiving and D&D"
 subtitle: "Update #18"
-dateCreated: "2022-11-28"
+date: "2022-11-28"
 tags: ["update"]
 ---
 

--- a/src/posts/19-sprained-ankle-and-interactive-fiction.md
+++ b/src/posts/19-sprained-ankle-and-interactive-fiction.md
@@ -1,7 +1,7 @@
 ---
 title: "#19 Sprained ankle and interactive fiction"
 subtitle: "Update #19"
-dateCreated: "2022-12-05"
+date: "2022-12-05"
 tags: ["update"]
 ---
 

--- a/src/posts/20-getting-ready-for-christmas.md
+++ b/src/posts/20-getting-ready-for-christmas.md
@@ -1,7 +1,7 @@
 ---
 title: "#20 Getting ready for Christmas"
 subtitle: "Update #20"
-dateCreated: "2022-12-16"
+date: "2022-12-16"
 tags: ["update"]
 ---
 

--- a/src/posts/2022-doodling.md
+++ b/src/posts/2022-doodling.md
@@ -1,7 +1,7 @@
 ---
 title: "2022 doodling"
 subtitle: "Playing around with my graphics tablet"
-dateCreated: "2022-12-29"
+date: "2022-12-29"
 tags: ["creative"]
 ---
 

--- a/src/posts/21-berlin-post-christmas.md
+++ b/src/posts/21-berlin-post-christmas.md
@@ -1,7 +1,7 @@
 ---
 title: "#21 Berlin post-Christmas"
 subtitle: "Update #21"
-dateCreated: "2022-12-27"
+date: "2022-12-27"
 tags: ["update"]
 ---
 

--- a/src/posts/22-gently-sliding-into-2023.md
+++ b/src/posts/22-gently-sliding-into-2023.md
@@ -1,7 +1,7 @@
 ---
 title: "#22 Gently sliding into 2023"
 subtitle: "Update #22"
-dateCreated: "2023-01-02"
+date: "2023-01-02"
 tags: ["update"]
 ---
 

--- a/src/posts/23-galette-des-rois-and-indieweb-nuggets.md
+++ b/src/posts/23-galette-des-rois-and-indieweb-nuggets.md
@@ -1,7 +1,7 @@
 ---
 title: "#23 Galette des rois and IndieWeb nuggets"
 subtitle: "Update #23"
-dateCreated: "2023-01-09"
+date: "2023-01-09"
 tags: ["update"]
 ---
 

--- a/src/posts/24-playing-with-games-and-typography.md
+++ b/src/posts/24-playing-with-games-and-typography.md
@@ -1,7 +1,7 @@
 ---
 title: "#24 Playing with games and typography"
 subtitle: "Update #24"
-dateCreated: "2023-01-19"
+date: "2023-01-19"
 tags: ["update"]
 ---
 

--- a/src/posts/25-unpacking-and-wood-stove-fires.md
+++ b/src/posts/25-unpacking-and-wood-stove-fires.md
@@ -1,7 +1,7 @@
 ---
 title: "#25 Unpacking and wood stove fires"
 subtitle: "Update #25"
-dateCreated: "2023-02-04"
+date: "2023-02-04"
 tags: ["update"]
 ---
 

--- a/src/posts/26-taking-the-time.md
+++ b/src/posts/26-taking-the-time.md
@@ -1,7 +1,7 @@
 ---
 title: "#26 Taking the time"
 subtitle: "Update #26"
-dateCreated: "2023-02-26"
+date: "2023-02-26"
 tags: ["update"]
 ---
 

--- a/src/posts/27-real-rock-climbing-and-more.md
+++ b/src/posts/27-real-rock-climbing-and-more.md
@@ -1,7 +1,7 @@
 ---
 title: "#27 (Real) rock climbing and more"
 subtitle: "Update #27"
-dateCreated: "2023-03-06"
+date: "2023-03-06"
 tags: ["update"]
 ---
 

--- a/src/posts/28-on-learning.md
+++ b/src/posts/28-on-learning.md
@@ -1,7 +1,7 @@
 ---
 title: "#28 On learning"
 subtitle: "Update #28"
-dateCreated: "2023-03-24"
+date: "2023-03-24"
 tags: ["update"]
 ---
 

--- a/src/posts/29-time-for-a-break.md
+++ b/src/posts/29-time-for-a-break.md
@@ -1,7 +1,7 @@
 ---
 title: "#29 Time for a break"
 subtitle: "Update #29"
-dateCreated: "2023-04-04"
+date: "2023-04-04"
 tags: ["update"]
 ---
 

--- a/src/posts/3-friends-and-digital-gardening.md
+++ b/src/posts/3-friends-and-digital-gardening.md
@@ -1,7 +1,7 @@
 ---
 title: "#3 Friends and digital gardening"
 subtitle: "Update #3"
-dateCreated: "2020-11-24"
+date: "2020-11-24"
 tags: ["update"]
 ---
 

--- a/src/posts/30-slow-start.md
+++ b/src/posts/30-slow-start.md
@@ -1,7 +1,7 @@
 ---
 title: "#30 Slow start"
 subtitle: "Update #30"
-dateCreated: "2023-04-20"
+date: "2023-04-20"
 tags: ["update"]
 ---
 

--- a/src/posts/31-friends-sci-fi-and-coppola.md
+++ b/src/posts/31-friends-sci-fi-and-coppola.md
@@ -1,7 +1,7 @@
 ---
 title: "#31 Friends, sci-fi and Coppola"
 subtitle: "Update #31"
-dateCreated: "2023-05-14"
+date: "2023-05-14"
 tags: ["update"]
 ---
 

--- a/src/posts/32-on-the-train-to-sicily.md
+++ b/src/posts/32-on-the-train-to-sicily.md
@@ -1,7 +1,7 @@
 ---
 title: "#32 On the train to Sicily"
 subtitle: "Update #32"
-dateCreated: "2023-05-21"
+date: "2023-05-21"
 tags: ["update"]
 ---
 

--- a/src/posts/33-post-sicily.md
+++ b/src/posts/33-post-sicily.md
@@ -1,7 +1,7 @@
 ---
 title: "#33 Post-Sicily"
 subtitle: "Update #33"
-dateCreated: "2023-06-05"
+date: "2023-06-05"
 tags: ["update"]
 ---
 

--- a/src/posts/34-mushroom-hunting-and-playing-with-words.md
+++ b/src/posts/34-mushroom-hunting-and-playing-with-words.md
@@ -1,7 +1,7 @@
 ---
 title: "#34 Mushroom hunting and playing with words"
 subtitle: "Update #34"
-dateCreated: "2023-06-19"
+date: "2023-06-19"
 tags: ["update"]
 ---
 

--- a/src/posts/35-from-one-project-to-the-next.md
+++ b/src/posts/35-from-one-project-to-the-next.md
@@ -1,7 +1,7 @@
 ---
 title: "#35 From one project to the next"
 subtitle: "Update #35"
-dateCreated: "2023-07-12"
+date: "2023-07-12"
 tags: ["update"]
 ---
 

--- a/src/posts/36-keeping-up-with-the-fruits-and-veggies.md
+++ b/src/posts/36-keeping-up-with-the-fruits-and-veggies.md
@@ -1,7 +1,7 @@
 ---
 title: "#36 Keeping up with the fruits and veggies"
 subtitle: "Update #36"
-dateCreated: "2023-08-08"
+date: "2023-08-08"
 tags: ["update"]
 ---
 

--- a/src/posts/37-ba-ngoai.md
+++ b/src/posts/37-ba-ngoai.md
@@ -1,7 +1,7 @@
 ---
 title: "#37 Bà ngoại"
 subtitle: "Update #37"
-dateCreated: "2023-09-20"
+date: "2023-09-20"
 tags: ["update"]
 ---
 

--- a/src/posts/38-hiking-eating-harvesting.md
+++ b/src/posts/38-hiking-eating-harvesting.md
@@ -1,7 +1,7 @@
 ---
 title: "#38 Hiking, eating, harvesting"
 subtitle: "Update #38"
-dateCreated: "2023-09-27"
+date: "2023-09-27"
 tags: ["update"]
 ---
 

--- a/src/posts/39-a-week-in-herault.md
+++ b/src/posts/39-a-week-in-herault.md
@@ -1,7 +1,7 @@
 ---
 title: "#39 A week in Hérault"
 subtitle: "Update #39"
-dateCreated: "2023-10-10"
+date: "2023-10-10"
 tags: ["update"]
 ---
 

--- a/src/posts/4-gluehwein-and-note-taking.md
+++ b/src/posts/4-gluehwein-and-note-taking.md
@@ -1,7 +1,7 @@
 ---
 title: "#4 Glühwein and note-taking"
 subtitle: "Update #4"
-dateCreated: "2020-11-28"
+date: "2020-11-28"
 tags: ["update"]
 ---
 

--- a/src/posts/40-brr.md
+++ b/src/posts/40-brr.md
@@ -1,7 +1,7 @@
 ---
 title: "#40 Brr"
 subtitle: "Update #40"
-dateCreated: "2023-10-17"
+date: "2023-10-17"
 tags: ["update"]
 ---
 

--- a/src/posts/41-chestnut-time.md
+++ b/src/posts/41-chestnut-time.md
@@ -1,7 +1,7 @@
 ---
 title: "#41 Chestnut time"
 subtitle: "Update #41"
-dateCreated: "2023-10-27"
+date: "2023-10-27"
 tags: ["update"]
 ---
 

--- a/src/posts/42-the-never-ending-to-do-list.md
+++ b/src/posts/42-the-never-ending-to-do-list.md
@@ -1,7 +1,7 @@
 ---
 title: "#42 The never-ending to-do list"
 subtitle: "Update #42"
-dateCreated: "2023-11-23"
+date: "2023-11-23"
 tags: ["update"]
 ---
 

--- a/src/posts/43-fondues-and-digital-storage.md
+++ b/src/posts/43-fondues-and-digital-storage.md
@@ -1,7 +1,7 @@
 ---
 title: "#43 Fondues and digital storage"
 subtitle: "Update #43"
-dateCreated: "2023-12-08"
+date: "2023-12-08"
 tags: ["update"]
 ---
 

--- a/src/posts/44-family-gatherings.md
+++ b/src/posts/44-family-gatherings.md
@@ -1,7 +1,7 @@
 ---
 title: "#44 Family gatherings"
 subtitle: "Update #44"
-dateCreated: "2023-12-24"
+date: "2023-12-24"
 tags: ["update"]
 ---
 

--- a/src/posts/45-turkish-experiences.md
+++ b/src/posts/45-turkish-experiences.md
@@ -1,7 +1,7 @@
 ---
 title: "#45 Turkish experiences"
 subtitle: "Update #45"
-dateCreated: "2024-01-07"
+date: "2024-01-07"
 tags: ["update"]
 ---
 

--- a/src/posts/46-three-thousand-kilometers.md
+++ b/src/posts/46-three-thousand-kilometers.md
@@ -1,7 +1,7 @@
 ---
 title: "#46 Three thousand kilometers"
 subtitle: "Update #46"
-dateCreated: "2024-01-27"
+date: "2024-01-27"
 tags: ["update"]
 ---
 

--- a/src/posts/47-four-months-on-the-road.md
+++ b/src/posts/47-four-months-on-the-road.md
@@ -1,7 +1,7 @@
 ---
 title: "#47 Four months on the road"
 subtitle: "Update #47"
-dateCreated: "2024-04-30"
+date: "2024-04-30"
 tags: ["update"]
 ---
 

--- a/src/posts/5-coffee-tasting-and-cozy-december.md
+++ b/src/posts/5-coffee-tasting-and-cozy-december.md
@@ -1,7 +1,7 @@
 ---
 title: "#5 Coffee tasting and cozy December"
 subtitle: "Update #5"
-dateCreated: "2020-12-05"
+date: "2020-12-05"
 tags: ["update"]
 ---
 

--- a/src/posts/6-bringing-home-some-old-records.md
+++ b/src/posts/6-bringing-home-some-old-records.md
@@ -1,7 +1,7 @@
 ---
 title: "#6 Bringing home some old records"
 subtitle: "Update #6"
-dateCreated: "2020-12-12"
+date: "2020-12-12"
 tags: ["update"]
 ---
 

--- a/src/posts/7-living-better-with-less.md
+++ b/src/posts/7-living-better-with-less.md
@@ -1,7 +1,7 @@
 ---
 title: "#7 Living better with less"
 subtitle: "Update #7"
-dateCreated: "2020-12-19"
+date: "2020-12-19"
 tags: ["update"]
 ---
 

--- a/src/posts/8-remote-christmas.md
+++ b/src/posts/8-remote-christmas.md
@@ -1,7 +1,7 @@
 ---
 title: "#8 Remote Christmas"
 subtitle: "Update #8"
-dateCreated: "2020-12-26"
+date: "2020-12-26"
 tags: ["update"]
 ---
 

--- a/src/posts/9-new-website-for-2021.md
+++ b/src/posts/9-new-website-for-2021.md
@@ -1,7 +1,7 @@
 ---
 title: "#9 New website for 2021"
 subtitle: "Update #9"
-dateCreated: "2021-01-02"
+date: "2021-01-02"
 tags: ["update"]
 ---
 

--- a/src/posts/a-list-of-berlin-things.md
+++ b/src/posts/a-list-of-berlin-things.md
@@ -1,7 +1,7 @@
 ---
 title: "A list of Berlin things"
 subtitle: "A non-comprehensive list of things I'll miss from Berlin"
-dateCreated: "2022-12-31"
+date: "2022-12-31"
 tags: ["thought"]
 ---
 

--- a/src/posts/a-walk-down-the-sonnenallee.md
+++ b/src/posts/a-walk-down-the-sonnenallee.md
@@ -1,7 +1,7 @@
 ---
 title: "A walk down the Sonnenallee"
 subtitle: "Along the Arab street, from Hermannplatz to Sonnenallee station"
-dateCreated: "2023-11-07"
+date: "2023-11-07"
 tags: ["thought"]
 ---
 

--- a/src/posts/add-a-crayon-effect-to-your-illustrations.md
+++ b/src/posts/add-a-crayon-effect-to-your-illustrations.md
@@ -1,7 +1,7 @@
 ---
 title: "Add a crayon effect to your illustrations"
 subtitle: "An Adobe Illustrator CC tutorial"
-dateCreated: "2019-04-30"
+date: "2019-04-30"
 tags: ["creative", "digital"]
 ---
 

--- a/src/posts/ce-que-jai-appris-a-berlin.md
+++ b/src/posts/ce-que-jai-appris-a-berlin.md
@@ -1,7 +1,7 @@
 ---
 title: "Choses que j'ai apprises à Berlin"
 subtitle: "Un exercise de poésie"
-dateCreated: "2023-08-20"
+date: "2023-08-20"
 tags: ["creative", "french"]
 ---
 

--- a/src/posts/city-kids-going-cottagecore.md
+++ b/src/posts/city-kids-going-cottagecore.md
@@ -1,7 +1,7 @@
 ---
 title: "City kids going cottagecore"
 subtitle: "Moving to the countryside"
-dateCreated: "2022-12-15"
+date: "2022-12-15"
 tags: ["thought"]
 ---
 

--- a/src/posts/comic-high-tech.md
+++ b/src/posts/comic-high-tech.md
@@ -1,7 +1,7 @@
 ---
 title: "High tech"
 subtitle: "Comic strip #1"
-dateCreated: "2021-10-19"
+date: "2021-10-19"
 tags: ["creative"]
 ---
 

--- a/src/posts/comic-obstacle.md
+++ b/src/posts/comic-obstacle.md
@@ -1,7 +1,7 @@
 ---
 title: "Obstacle"
 subtitle: "Comic strip #2"
-dateCreated: "2021-10-21"
+date: "2021-10-21"
 tags: ["creative"]
 ---
 

--- a/src/posts/create-a-duotone-image-in-5-minutes.md
+++ b/src/posts/create-a-duotone-image-in-5-minutes.md
@@ -1,7 +1,7 @@
 ---
 title: "Create a duotone image in 5 minutes"
 subtitle: "An Adobe Photoshop CC tutorial"
-dateCreated: "2019-05-09"
+date: "2019-05-09"
 tags: ["creative", "digital"]
 ---
 

--- a/src/posts/dans-la-cabane.md
+++ b/src/posts/dans-la-cabane.md
@@ -1,7 +1,7 @@
 ---
 title: "Dans la cabane"
 subtitle: "Un exercise de poésie"
-dateCreated: "2023-06-16"
+date: "2023-06-16"
 tags: ["creative", "french"]
 ---
 

--- a/src/posts/dans-le-quartier-de-thanh-cong-il-y-a-le-village-de-thanh-cong-2004.md
+++ b/src/posts/dans-le-quartier-de-thanh-cong-il-y-a-le-village-de-thanh-cong-2004.md
@@ -1,7 +1,7 @@
 ---
 title: "Dans le quartier de Thanh Công il y a le village de Thanh Công (2004)"
 subtitle: "A tiny note about the short"
-dateCreated: "2023-04-02"
+date: "2023-04-02"
 tags: ["review"]
 ---
 

--- a/src/posts/destination.md
+++ b/src/posts/destination.md
@@ -1,7 +1,7 @@
 ---
 title: "Destination"
 subtitle: "A stop motion experiment"
-dateCreated: "2022-02-13"
+date: "2022-02-13"
 tags: ["creative"]
 ---
 

--- a/src/posts/digital-doodling.md
+++ b/src/posts/digital-doodling.md
@@ -1,7 +1,7 @@
 ---
 title: "Digital doodling"
 subtitle: "Trying out Tayasui Sketches"
-dateCreated: "2021-12-25"
+date: "2021-12-25"
 tags: ["creative"]
 ---
 

--- a/src/posts/down-by-law-1986.md
+++ b/src/posts/down-by-law-1986.md
@@ -1,7 +1,7 @@
 ---
 title: "Down By Law (1986)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-11-26"
+date: "2020-11-26"
 tags: ["review"]
 ---
 

--- a/src/posts/fermentation-behind-the-scenes.md
+++ b/src/posts/fermentation-behind-the-scenes.md
@@ -1,7 +1,7 @@
 ---
 title: "Fermentation: behind-the-scenes"
 subtitle: "Biochemistry stuff I barely understand"
-dateCreated: "2023-07-27"
+date: "2023-07-27"
 tags: ["thought"]
 ---
 

--- a/src/posts/free-solo-2018.md
+++ b/src/posts/free-solo-2018.md
@@ -1,7 +1,7 @@
 ---
 title: "Free Solo (2018)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-11-26"
+date: "2020-11-26"
 tags: ["review"]
 ---
 

--- a/src/posts/gardening.md
+++ b/src/posts/gardening.md
@@ -1,7 +1,7 @@
 ---
 title: "Gardening"
 subtitle: "Another try at knowledge management"
-dateCreated: "2021-10-24"
+date: "2021-10-24"
 tags: ["thought"]
 ---
 

--- a/src/posts/i-made-a-font.md
+++ b/src/posts/i-made-a-font.md
@@ -1,7 +1,7 @@
 ---
 title: "I made a font"
 subtitle: "Or how I created a simple font as a complete typography-noob"
-dateCreated: "2023-01-10"
+date: "2023-01-10"
 tags: ["creative", "digital"]
 ---
 

--- a/src/posts/implementing-static-comments-with-staticman.md
+++ b/src/posts/implementing-static-comments-with-staticman.md
@@ -1,7 +1,7 @@
 ---
 title: "Implementing static comments with Staticman"
 subtitle: "Back on the coding train"
-dateCreated: "2024-05-20"
+date: "2024-05-20"
 tags: ["digital"]
 ---
 

--- a/src/posts/in-bruges-2018.md
+++ b/src/posts/in-bruges-2018.md
@@ -1,7 +1,7 @@
 ---
 title: "In Bruges (2008)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-12-19"
+date: "2020-12-19"
 tags: ["review"]
 ---
 

--- a/src/posts/indieweb-browsing.md
+++ b/src/posts/indieweb-browsing.md
@@ -1,7 +1,7 @@
 ---
 title: "IndieWeb browsing"
 subtitle: "How I lost myself in the webring"
-dateCreated: "2022-04-16"
+date: "2022-04-16"
 tags: ["digital"]
 ---
 

--- a/src/posts/interactive-fiction.md
+++ b/src/posts/interactive-fiction.md
@@ -1,7 +1,7 @@
 ---
 title: "Interactive fiction"
 subtitle: "So I got into text adventure games"
-dateCreated: "2022-04-06"
+date: "2022-04-06"
 tags: []
 ---
 

--- a/src/posts/just-the-two-of-us.md
+++ b/src/posts/just-the-two-of-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Just the two of us"
 subtitle: "A tiny note about life stuff"
-dateCreated: "2023-05-29"
+date: "2023-05-29"
 tags: ["thought"]
 ---
 

--- a/src/posts/last-homage-to-my-old-website.md
+++ b/src/posts/last-homage-to-my-old-website.md
@@ -1,7 +1,7 @@
 ---
 title: "Last homage to my old website"
 subtitle: "A toast to all lost websites"
-dateCreated: "2022-04-03"
+date: "2022-04-03"
 tags: ["thought"]
 ---
 

--- a/src/posts/my-first-indieweb-steps.md
+++ b/src/posts/my-first-indieweb-steps.md
@@ -1,7 +1,7 @@
 ---
 title: "Peeking into the IndieWeb world"
 subtitle: "My first baby steps"
-dateCreated: "2022-04-10"
+date: "2022-04-10"
 tags: ["digital"]
 ---
 

--- a/src/posts/my-quest-for-true-small-caps.md
+++ b/src/posts/my-quest-for-true-small-caps.md
@@ -1,7 +1,7 @@
 ---
 title: "My quest for true small caps"
 subtitle: "A web design adventure"
-dateCreated: "2021-01-07"
+date: "2021-01-07"
 tags: ["digital"]
 ---
 

--- a/src/posts/now-archive-1.md
+++ b/src/posts/now-archive-1.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #1"
 subtitle: "A snapshot in time"
-dateCreated: "2021-08-21"
+date: "2021-08-21"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-2.md
+++ b/src/posts/now-archive-2.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #2"
 subtitle: "A snapshot in time"
-dateCreated: "2021-10-24"
+date: "2021-10-24"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-3.md
+++ b/src/posts/now-archive-3.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #3"
 subtitle: "A snapshot in time"
-dateCreated: "2022-02-20"
+date: "2022-02-20"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-4.md
+++ b/src/posts/now-archive-4.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #4"
 subtitle: "A snapshot in time"
-dateCreated: "2022-06-25"
+date: "2022-06-25"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-5.md
+++ b/src/posts/now-archive-5.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #5"
 subtitle: "A snapshot in time"
-dateCreated: "2022-11-04"
+date: "2022-11-04"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-6.md
+++ b/src/posts/now-archive-6.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #6"
 subtitle: "A snapshot in time"
-dateCreated: "2023-02-06"
+date: "2023-02-06"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-7.md
+++ b/src/posts/now-archive-7.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #7"
 subtitle: "A snapshot in time"
-dateCreated: "2023-05-17"
+date: "2023-05-17"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-8.md
+++ b/src/posts/now-archive-8.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #8"
 subtitle: "A snapshot in time"
-dateCreated: "2023-07-12"
+date: "2023-07-12"
 tags: ["now"]
 ---
 

--- a/src/posts/now-archive-9.md
+++ b/src/posts/now-archive-9.md
@@ -1,7 +1,7 @@
 ---
 title: "Now archive #9"
 subtitle: "A snapshot in time"
-dateCreated: "2023-11-17"
+date: "2023-11-17"
 tags: ["now"]
 ---
 

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -2,7 +2,7 @@
 // Source docs: https://www.11ty.dev/docs/data-computed/
 module.exports = {
   eleventyComputed: {
-    // Generate post creation year automatically from dateCreated frontmatter
+    // Generate post creation year automatically from date frontmatter
     yearCreated: (data) => new Date(data.date).getFullYear(),
   },
   layout: "layout/post.njk",

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -3,9 +3,7 @@
 module.exports = {
   eleventyComputed: {
     // Generate post creation year automatically from dateCreated frontmatter
-    yearCreated: (data) => new Date(data.dateCreated).getFullYear(),
-    // Publishing date, recognized as a real date for RSS
-    dateCreated: (data) => new Date(data.dateCreated),
+    yearCreated: (data) => new Date(data.date).getFullYear(),
   },
   layout: "layout/post.njk",
   tags: "posts",

--- a/src/posts/seven-psychopaths-2012.md
+++ b/src/posts/seven-psychopaths-2012.md
@@ -1,7 +1,7 @@
 ---
 title: "Seven Psychopaths (2012)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-11-26"
+date: "2020-11-26"
 tags: ["review"]
 ---
 

--- a/src/posts/sicilian-notes.md
+++ b/src/posts/sicilian-notes.md
@@ -1,7 +1,7 @@
 ---
 title: "Sicilian notes"
 subtitle: "A tiny note about our trip in Sicily"
-dateCreated: "2023-06-02"
+date: "2023-06-02"
 tags: ["thought"]
 ---
 

--- a/src/posts/sick-days-cheatsheet.md
+++ b/src/posts/sick-days-cheatsheet.md
@@ -1,7 +1,7 @@
 ---
 title: "Sick days cheatsheet"
 subtitle: "Or how to help my tired cloudy mind"
-dateCreated: "2022-11-30"
+date: "2022-11-30"
 tags: ["thought"]
 ---
 

--- a/src/posts/split-2016.md
+++ b/src/posts/split-2016.md
@@ -1,7 +1,7 @@
 ---
 title: "Split (2016)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-12-21"
+date: "2020-12-21"
 tags: ["review"]
 ---
 

--- a/src/posts/styling-animated-rainbow-links.md
+++ b/src/posts/styling-animated-rainbow-links.md
@@ -1,7 +1,7 @@
 ---
 title: "Styling animated rainbow links"
 subtitle: "With CSS only"
-dateCreated: "2022-04-15"
+date: "2022-04-15"
 tags: ["digital"]
 ---
 

--- a/src/posts/the-good-the-bad-and-the-ugly-1966.md
+++ b/src/posts/the-good-the-bad-and-the-ugly-1966.md
@@ -1,7 +1,7 @@
 ---
 title: "The Good, the Bad and the Ugly (1966)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-12-05"
+date: "2020-12-05"
 tags: ["review"]
 ---
 

--- a/src/posts/the-guernsey-literary-and-potato-peel-pie-society.md
+++ b/src/posts/the-guernsey-literary-and-potato-peel-pie-society.md
@@ -1,7 +1,7 @@
 ---
 title: "The Guernsey Literary and Potato Peel Pie Society"
 subtitle: "A review of the audiobook"
-dateCreated: "2022-04-09"
+date: "2022-04-09"
 tags: ["review"]
 ---
 

--- a/src/posts/the-host-2006.md
+++ b/src/posts/the-host-2006.md
@@ -1,7 +1,7 @@
 ---
 title: "The Host (2006)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-12-12"
+date: "2020-12-12"
 tags: ["review"]
 ---
 

--- a/src/posts/the-untouchables-1987.md
+++ b/src/posts/the-untouchables-1987.md
@@ -1,7 +1,7 @@
 ---
 title: "The Untouchables (1987)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-12-11"
+date: "2020-12-11"
 tags: ["review"]
 ---
 

--- a/src/posts/three-years-blogging.md
+++ b/src/posts/three-years-blogging.md
@@ -1,7 +1,7 @@
 ---
 title: "Three years blogging"
 subtitle: "And apparently still going"
-dateCreated: "2023-11-26"
+date: "2023-11-26"
 tags: ["thought"]
 ---
 

--- a/src/posts/ui-ux-learnings.md
+++ b/src/posts/ui-ux-learnings.md
@@ -1,7 +1,7 @@
 ---
 title: "UI/UX Learnings"
 subtitle: "Living notes"
-dateCreated: "2022-07-13"
+date: "2022-07-13"
 tags: ["digital"]
 ---
 

--- a/src/posts/victoria-2015.md
+++ b/src/posts/victoria-2015.md
@@ -1,7 +1,7 @@
 ---
 title: "Victoria (2015)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-11-26"
+date: "2020-11-26"
 tags: ["review"]
 ---
 

--- a/src/posts/waking-up-in-berlin.md
+++ b/src/posts/waking-up-in-berlin.md
@@ -1,7 +1,7 @@
 ---
 title: "Waking up in Berlin"
 subtitle: "A last note"
-dateCreated: "2023-01-29"
+date: "2023-01-29"
 tags: ["thought"]
 ---
 

--- a/src/posts/wonder-woman-1984-2020.md
+++ b/src/posts/wonder-woman-1984-2020.md
@@ -1,7 +1,7 @@
 ---
 title: "Wonder Woman 1984 (2020)"
 subtitle: "A tiny note about the movie"
-dateCreated: "2020-12-26"
+date: "2020-12-26"
 tags: ["review"]
 ---
 

--- a/src/posts/words-i-m-growing-suspicious-of.md
+++ b/src/posts/words-i-m-growing-suspicious-of.md
@@ -1,7 +1,7 @@
 ---
 title: "Words I'm growing suspicious of"
 subtitle: "Ranting (in a list format)"
-dateCreated: "2023-12-12"
+date: "2023-12-12"
 tags: ["thought"]
 ---
 

--- a/src/recipes/asparagus-and-baked-potatoes.json
+++ b/src/recipes/asparagus-and-baked-potatoes.json
@@ -1,6 +1,6 @@
 {
   "title": "Asparagus and baked potatoes",
-  "dateCreated": "2022-06-18",
+  "date": "2022-06-18",
   "dataTag": ["main", "spring"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/banana-bread.json
+++ b/src/recipes/banana-bread.json
@@ -1,6 +1,6 @@
 {
   "title": "Banana bread",
-  "dateCreated": "2021-02-05",
+  "date": "2021-02-05",
   "dataTag": ["dessert", "ahead"],
   "intro": "This is a recipe that Niamh recommended to me. And as with most dessert recipes, she was spot on. Definitely one of the best banana breads I have eaten. It has a very strong banana taste, is moist in the inside, but crispy on the outside.",
   "duration": "110",

--- a/src/recipes/banana-ice-cream.json
+++ b/src/recipes/banana-ice-cream.json
@@ -1,6 +1,6 @@
 {
   "title": "Banana ice cream",
-  "dateCreated": "2023-06-30",
+  "date": "2023-06-30",
   "dataTag": ["dessert", "ahead", "summer"],
   "intro": "",
   "duration": "140",

--- a/src/recipes/basic-millet.json
+++ b/src/recipes/basic-millet.json
@@ -1,6 +1,6 @@
 {
   "title": "Basic millet",
-  "dateCreated": "2022-10-06",
+  "date": "2022-10-06",
   "dataTag": ["side"],
   "intro": "",
   "duration": "45",

--- a/src/recipes/beetroot-carpaccio.json
+++ b/src/recipes/beetroot-carpaccio.json
@@ -1,6 +1,6 @@
 {
   "title": "Beetroot carpaccio",
-  "dateCreated": "2023-03-09",
+  "date": "2023-03-09",
   "dataTag": ["side", "ahead", "fall", "winter"],
   "intro": "",
   "duration": "30",

--- a/src/recipes/bell-pepper-spread.json
+++ b/src/recipes/bell-pepper-spread.json
@@ -1,6 +1,6 @@
 {
   "title": "Bell pepper spread",
-  "dateCreated": "2022-10-31",
+  "date": "2022-10-31",
   "dataTag": ["ahead", "side", "summer"],
   "intro": "",
   "duration": "40",

--- a/src/recipes/brazilian-crispy-smashed-potatoes.json
+++ b/src/recipes/brazilian-crispy-smashed-potatoes.json
@@ -1,6 +1,6 @@
 {
   "title": "Brazilian crispy smashed potatoes",
-  "dateCreated": "2022-10-06",
+  "date": "2022-10-06",
   "dataTag": ["side"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/brownies.json
+++ b/src/recipes/brownies.json
@@ -1,6 +1,6 @@
 {
   "title": "Brownies",
-  "dateCreated": "2021-03-24",
+  "date": "2021-03-24",
   "dataTag": ["dessert", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/bulgarian-national-salad.json
+++ b/src/recipes/bulgarian-national-salad.json
@@ -1,6 +1,6 @@
 {
   "title": "Bulgarian national salad (shopska)",
-  "dateCreated": "2022-11-12",
+  "date": "2022-11-12",
   "dataTag": ["side", "ahead", "summer", "fall"],
   "intro": "I was introduced to this super simple salad recipe when traveling in Eastern Europe. A similar recipe exists in multiple of those countries, and always stars three main ingredients: cucumbers, tomatoes and feta. From there, everything else is optional.",
   "duration": "15",

--- a/src/recipes/chinese-chili-oil.json
+++ b/src/recipes/chinese-chili-oil.json
@@ -1,6 +1,6 @@
 {
   "title": "Chinese chili oil",
-  "dateCreated": "2022-04-29",
+  "date": "2022-04-29",
   "dataTag": ["side"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/clafoutis.json
+++ b/src/recipes/clafoutis.json
@@ -1,6 +1,6 @@
 {
   "title": "Clafoutis",
-  "dateCreated": "2023-07-18",
+  "date": "2023-07-18",
   "dataTag": ["dessert", "ahead", "summer"],
   "intro": "Recette d'un vieux bouquin de cuisine de France.",
   "duration": "35",

--- a/src/recipes/cleaning-spray-for-everything.json
+++ b/src/recipes/cleaning-spray-for-everything.json
@@ -1,6 +1,6 @@
 {
   "title": "Cleaning spray for everything",
-  "dateCreated": "2023-02-13",
+  "date": "2023-02-13",
   "dataTag": ["diy"],
   "intro": "",
   "duration": "10",

--- a/src/recipes/cold-spicy-noodles.json
+++ b/src/recipes/cold-spicy-noodles.json
@@ -1,6 +1,6 @@
 {
   "title": "Cold spicy noodles",
-  "dateCreated": "2023-08-25",
+  "date": "2023-08-25",
   "dataTag": ["main"],
   "intro": "",
   "duration": "30",

--- a/src/recipes/couscous.json
+++ b/src/recipes/couscous.json
@@ -1,6 +1,6 @@
 {
   "title": "Couscous",
-  "dateCreated": "2023-10-29",
+  "date": "2023-10-29",
   "dataTag": ["main"],
   "intro": "Recette de couscous de Souad, préparée ensemble pour la première fois à Joux en octobre 2023. Il fait légèrement frais dehors, on allume le poêle et on mange tous et toutes du même plat. Autour de la table : France, Souad, Greg, Karima, Thibaud, Robin et moi.",
   "duration": "130",

--- a/src/recipes/crispy-oven-fries.json
+++ b/src/recipes/crispy-oven-fries.json
@@ -1,6 +1,6 @@
 {
   "title": "Crispy oven fries",
-  "dateCreated": "2022-04-07",
+  "date": "2022-04-07",
   "dataTag": ["side"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/croutons.json
+++ b/src/recipes/croutons.json
@@ -1,6 +1,6 @@
 {
   "title": "Croûtons",
-  "dateCreated": "2023-04-20",
+  "date": "2023-04-20",
   "dataTag": ["side", "ahead"],
   "intro": "",
   "duration": "20",

--- a/src/recipes/dumpling-soup-with-egg-whites.json
+++ b/src/recipes/dumpling-soup-with-egg-whites.json
@@ -1,6 +1,6 @@
 {
   "title": "Dumpling soup with egg whites",
-  "dateCreated": "2022-11-08",
+  "date": "2022-11-08",
   "dataTag": ["main", "fall", "winter", "ahead"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/eggplant-tarte-tatin.json
+++ b/src/recipes/eggplant-tarte-tatin.json
@@ -1,6 +1,6 @@
 {
   "title": "Eggplant tarte tatin",
-  "dateCreated": "2023-07-29",
+  "date": "2023-07-29",
   "dataTag": ["main", "ahead", "summer"],
   "intro": "I love tarte tatin. This recipe is Asian-inspired and just hits the right spots for me.",
   "duration": "60",

--- a/src/recipes/eggplants-with-tahini-miso.json
+++ b/src/recipes/eggplants-with-tahini-miso.json
@@ -1,6 +1,6 @@
 {
   "title": "Eggplants with a tahini-miso sauce",
-  "dateCreated": "2023-09-27",
+  "date": "2023-09-27",
   "dataTag": ["main", "summer"],
   "intro": "",
   "duration": "45",

--- a/src/recipes/endive-pie.json
+++ b/src/recipes/endive-pie.json
@@ -1,6 +1,6 @@
 {
   "title": "Endive pie",
-  "dateCreated": "2022-11-12",
+  "date": "2022-11-12",
   "dataTag": ["main", "ahead", "fall"],
   "intro": "",
   "duration": "50",

--- a/src/recipes/fennel-salad.json
+++ b/src/recipes/fennel-salad.json
@@ -1,6 +1,6 @@
 {
   "title": "Fennel salad",
-  "dateCreated": "2022-06-06",
+  "date": "2022-06-06",
   "dataTag": ["side"],
   "intro": "",
   "duration": "15",

--- a/src/recipes/fig-pie.json
+++ b/src/recipes/fig-pie.json
@@ -1,6 +1,6 @@
 {
   "title": "Fig pie",
-  "dateCreated": "2023-09-01",
+  "date": "2023-09-01",
   "dataTag": ["dessert", "summer"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/flan.json
+++ b/src/recipes/flan.json
@@ -1,6 +1,6 @@
 {
   "title": "Flan",
-  "dateCreated": "2023-08-08",
+  "date": "2023-08-08",
   "dataTag": ["dessert"],
   "intro": "L'une des premières recettes que j'ai appris à faire petite.",
   "duration": "70",

--- a/src/recipes/freeze-spinach-leaves.json
+++ b/src/recipes/freeze-spinach-leaves.json
@@ -1,6 +1,6 @@
 {
   "title": "Freeze spinach leaves",
-  "dateCreated": "2023-06-14",
+  "date": "2023-06-14",
   "dataTag": ["side", "ahead", "spring", "preserve"],
   "intro": "It is currently full spring-summer here in Ardèche. We have a lot of amaranth plants growing as weeds among our garden vegetables. Instead of discarding them, the leaves are great to use as an alternative to spinach. Here is a good way to store them for winter.",
   "duration": "20",

--- a/src/recipes/fresh-cheese.json
+++ b/src/recipes/fresh-cheese.json
@@ -1,6 +1,6 @@
 {
   "title": "Fresh cheese",
-  "dateCreated": "2019-01-27",
+  "date": "2019-01-27",
   "dataTag": ["side"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/gaspacho.json
+++ b/src/recipes/gaspacho.json
@@ -1,6 +1,6 @@
 {
   "title": "Gaspacho",
-  "dateCreated": "2023-07-30",
+  "date": "2023-07-30",
   "dataTag": ["main", "summer"],
   "intro": "",
   "duration": "30",

--- a/src/recipes/german-sauerkraut.json
+++ b/src/recipes/german-sauerkraut.json
@@ -1,6 +1,6 @@
 {
   "title": "German Sauerkraut",
-  "dateCreated": "2022-03-06",
+  "date": "2022-03-06",
   "dataTag": ["side", "fall", "winter"],
   "intro": "",
   "duration": "",

--- a/src/recipes/german-sweet-red-cabbage.json
+++ b/src/recipes/german-sweet-red-cabbage.json
@@ -1,6 +1,6 @@
 {
   "title": "German sweet red cabbage",
-  "dateCreated": "2022-10-06",
+  "date": "2022-10-06",
   "dataTag": ["main", "fall", "winter", "ahead"],
   "intro": "",
   "duration": "75",

--- a/src/recipes/german-tyrolean-knoedel.json
+++ b/src/recipes/german-tyrolean-knoedel.json
@@ -1,6 +1,6 @@
 {
   "title": "German Tyrolean Knödel",
-  "dateCreated": "2022-12-04",
+  "date": "2022-12-04",
   "dataTag": ["main", "ahead"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/greek-tzatziki.json
+++ b/src/recipes/greek-tzatziki.json
@@ -1,6 +1,6 @@
 {
   "title": "Greek tzatziki",
-  "dateCreated": "2023-04-27",
+  "date": "2023-04-27",
   "dataTag": ["side", "ahead", "summer"],
   "intro": "",
   "duration": "20",

--- a/src/recipes/green-tomato-chutney.json
+++ b/src/recipes/green-tomato-chutney.json
@@ -1,6 +1,6 @@
 {
   "title": "Green tomato chutney",
-  "dateCreated": "2022-10-06",
+  "date": "2022-10-06",
   "dataTag": ["side", "summer", "fall"],
   "intro": "",
   "duration": "80",

--- a/src/recipes/hollandaise-sauce.json
+++ b/src/recipes/hollandaise-sauce.json
@@ -1,6 +1,6 @@
 {
   "title": "Hollandaise sauce",
-  "dateCreated": "2023-02-04",
+  "date": "2023-02-04",
   "dataTag": ["side", "ahead"],
   "intro": "",
   "duration": "20",

--- a/src/recipes/hummus.json
+++ b/src/recipes/hummus.json
@@ -1,6 +1,6 @@
 {
   "title": "Hummus",
-  "dateCreated": "2023-04-27",
+  "date": "2023-04-27",
   "dataTag": ["side", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/immunity-shots.json
+++ b/src/recipes/immunity-shots.json
@@ -1,6 +1,6 @@
 {
   "title": "Immunity shots",
-  "dateCreated": "2023-11-17",
+  "date": "2023-11-17",
   "dataTag": ["ahead", "winter", "fall"],
   "intro": "Prepare these frozen immunity shots early winter to be ready for the cold season.",
   "duration": "30",

--- a/src/recipes/indian-dal-tadka.json
+++ b/src/recipes/indian-dal-tadka.json
@@ -1,6 +1,6 @@
 {
   "title": "Indian dal tadka",
-  "dateCreated": "2020-12-24",
+  "date": "2020-12-24",
   "dataTag": ["main", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/indian-ghee.json
+++ b/src/recipes/indian-ghee.json
@@ -1,6 +1,6 @@
 {
   "title": "Indian ghee",
-  "dateCreated": "2026-01-01",
+  "date": "2026-01-01",
   "dataTag": ["ahead", "preserve"],
   "intro": "Love the nutty taste and flavor! Bonus points as it can be made out of stale butter.",
   "duration": "40",

--- a/src/recipes/indian-pav-bhaji.json
+++ b/src/recipes/indian-pav-bhaji.json
@@ -1,6 +1,6 @@
 {
   "title": "Indian pav bhaji",
-  "dateCreated": "2020-10-10",
+  "date": "2020-10-10",
   "dataTag": ["main"],
   "intro": "",
   "duration": "120",

--- a/src/recipes/italian-arancini.json
+++ b/src/recipes/italian-arancini.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian arancini",
-  "dateCreated": "2022-12-08",
+  "date": "2022-12-08",
   "dataTag": ["main", "ahead"],
   "intro": "",
   "duration": "50",

--- a/src/recipes/italian-bolognese.json
+++ b/src/recipes/italian-bolognese.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian bolognese",
-  "dateCreated": "2023-01-01",
+  "date": "2023-01-01",
   "dataTag": ["main"],
   "intro": "This is Valentina's family recipe. Her great-grandma used to make her own tomato paste from scratch. Her grandma reviewed the recipe with some store-bought tomato paste, which works just fine. The secret is chopping the vegetables into super tiny pieces and using tomato paste instead of tomato sauce.",
   "duration": "120",

--- a/src/recipes/italian-cacio-e-pepe.json
+++ b/src/recipes/italian-cacio-e-pepe.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian cacio e pepe",
-  "dateCreated": "2021-02-25",
+  "date": "2021-02-25",
   "dataTag": ["main"],
   "intro": "I love the one-pan hack of this super creamy cacio e pepe!",
   "duration": "30",

--- a/src/recipes/italian-carbonara.json
+++ b/src/recipes/italian-carbonara.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian carbonara",
-  "dateCreated": "2022-11-12",
+  "date": "2022-11-12",
   "dataTag": ["main"],
   "intro": "Matteo and Valentina introduced Robin and I to an authentic carbonara recipe. It is apparently only one of many subtle variations, as they argued over many details during the cooking process. Just loved learning it with a glass of red wine!",
   "duration": "50",

--- a/src/recipes/italian-gnocchi.json
+++ b/src/recipes/italian-gnocchi.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian gnocchi",
-  "dateCreated": "2019-05-24",
+  "date": "2019-05-24",
   "dataTag": ["side", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/italian-lasagna.json
+++ b/src/recipes/italian-lasagna.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian lasagna",
-  "dateCreated": "2023-02-04",
+  "date": "2023-02-04",
   "dataTag": ["main", "ahead"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/italian-pesto-alla-trapanese.json
+++ b/src/recipes/italian-pesto-alla-trapanese.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian pesto alla trapanese",
-  "dateCreated": "2023-06-10",
+  "date": "2023-06-10",
   "dataTag": ["main", "ahead", "summer"],
   "intro": "I discovered this pasta sauce recipe, as I was traveling with friends through Sicily in 2023. It is fresh, tomato-ey, and just perfect for summer.",
   "duration": "30",

--- a/src/recipes/italian-ravioli.json
+++ b/src/recipes/italian-ravioli.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian ravioli",
-  "dateCreated": "2022-10-11",
+  "date": "2022-10-11",
   "dataTag": ["main"],
   "intro": "",
   "duration": "180",

--- a/src/recipes/italian-ribollita.json
+++ b/src/recipes/italian-ribollita.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian ribollita",
-  "dateCreated": "2020-06-24",
+  "date": "2020-06-24",
   "dataTag": ["main", "fall", "winter", "ahead"],
   "intro": "Robin and I discovered ribollita during our tandem bike trip in the Chianti region. We actually rarely use the traditional ingredients, but we love the concept of using up any kinds of vegetables and old bread you have on hand to create a filling soup.",
   "duration": "80",

--- a/src/recipes/italian-taralli.json
+++ b/src/recipes/italian-taralli.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian taralli",
-  "dateCreated": "2022-12-11",
+  "date": "2022-12-11",
   "dataTag": ["side", "ahead"],
   "intro": "I finally made my own taralli after trying them multiple times in Italian bars with Valentina, Matteo and Robin.",
   "duration": "70",

--- a/src/recipes/italian-tiramisu.json
+++ b/src/recipes/italian-tiramisu.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian tiramisu",
-  "dateCreated": "2022-11-20",
+  "date": "2022-11-20",
   "dataTag": ["dessert", "ahead"],
   "intro": "Tiramisu must be one of my favorite desserts. Beware the day I'll own an espresso machine, I'll be making tiramisu all the time.",
   "duration": "30",

--- a/src/recipes/italian-veggie-schiaccata.json
+++ b/src/recipes/italian-veggie-schiaccata.json
@@ -1,6 +1,6 @@
 {
   "title": "Italian veggie schiaccata",
-  "dateCreated": "2023-09-26",
+  "date": "2023-09-26",
   "dataTag": ["side", "main"],
   "intro": "Great to eat as a side or even as a main dish with some accompanying sauce.",
   "duration": "45",

--- a/src/recipes/jam.json
+++ b/src/recipes/jam.json
@@ -1,6 +1,6 @@
 {
   "title": "Jam",
-  "dateCreated": "2023-07-31",
+  "date": "2023-07-31",
   "dataTag": ["side", "preserve"],
   "intro": "I love Robin's family jam recipe. The result is not too sweet, syrupy with big pieces of fruits left.",
   "duration": "240",

--- a/src/recipes/japanese-pickled-ginger.json
+++ b/src/recipes/japanese-pickled-ginger.json
@@ -1,6 +1,6 @@
 {
   "title": "Japanese pickled ginger",
-  "dateCreated": "2022-10-06",
+  "date": "2022-10-06",
   "dataTag": ["side", "preserve"],
   "intro": "",
   "duration": "80",

--- a/src/recipes/korean-kimchi-stew.json
+++ b/src/recipes/korean-kimchi-stew.json
@@ -1,6 +1,6 @@
 {
   "title": "Korean kimchi stew (kimchijigae)",
-  "dateCreated": "2019-01-27",
+  "date": "2019-01-27",
   "dataTag": ["main", "fall", "winter", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/korean-kimchi.json
+++ b/src/recipes/korean-kimchi.json
@@ -1,6 +1,6 @@
 {
   "title": "Korean kimchi",
-  "dateCreated": "2022-02-10",
+  "date": "2022-02-10",
   "dataTag": ["side", "fall", "winter", "preserve"],
   "intro": "I love fermenting stuff. Kimchi is one of the first fermenting recipes I learned. It is the perfect addition to any dish you want to brighten or spice a bit.",
   "duration": "90",

--- a/src/recipes/korean-kimchijeon.json
+++ b/src/recipes/korean-kimchijeon.json
@@ -1,6 +1,6 @@
 {
   "title": "Korean kimchijeon",
-  "dateCreated": "2023-04-05",
+  "date": "2023-04-05",
   "dataTag": ["main", "spring"],
   "intro": "",
   "duration": "40",

--- a/src/recipes/korean-side-spinach.json
+++ b/src/recipes/korean-side-spinach.json
@@ -1,6 +1,6 @@
 {
   "title": "Korean side-spinach (sigeumchi namul)",
-  "dateCreated": "2020-11-15",
+  "date": "2020-11-15",
   "dataTag": ["main", "spring", "summer", "fall"],
   "intro": "",
   "duration": "",

--- a/src/recipes/korean-steamed-eggs.json
+++ b/src/recipes/korean-steamed-eggs.json
@@ -1,6 +1,6 @@
 {
   "title": "Korean steamed eggs (gyeran-jjim)",
-  "dateCreated": "2022-01-08",
+  "date": "2022-01-08",
   "dataTag": ["main"],
   "intro": "",
   "duration": "15",

--- a/src/recipes/lacto-fermentated-veggies.json
+++ b/src/recipes/lacto-fermentated-veggies.json
@@ -1,6 +1,6 @@
 {
   "title": "Lacto fermented veggies",
-  "dateCreated": "2022-08-15",
+  "date": "2022-08-15",
   "dataTag": ["side", "summer", "fall", "preserve"],
   "intro": "",
   "duration": "30",

--- a/src/recipes/leek-pie.json
+++ b/src/recipes/leek-pie.json
@@ -1,6 +1,6 @@
 {
   "title": "Leek pie",
-  "dateCreated": "2022-11-30",
+  "date": "2022-11-30",
   "dataTag": ["main", "ahead", "fall", "winter"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/lemon-bars.json
+++ b/src/recipes/lemon-bars.json
@@ -1,6 +1,6 @@
 {
   "title": "Lemon bars",
-  "dateCreated": "2021-01-21",
+  "date": "2021-01-21",
   "dataTag": ["dessert", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/lemon-pie.json
+++ b/src/recipes/lemon-pie.json
@@ -1,6 +1,6 @@
 {
   "title": "Lemon pie",
-  "dateCreated": "2022-03-14",
+  "date": "2022-03-14",
   "dataTag": ["dessert", "fall"],
   "intro": "",
   "duration": "",

--- a/src/recipes/lemon-risotto.json
+++ b/src/recipes/lemon-risotto.json
@@ -1,6 +1,6 @@
 {
   "title": "Lemon risotto",
-  "dateCreated": "2022-03-04",
+  "date": "2022-03-04",
   "dataTag": ["main", "fall"],
   "intro": "",
   "duration": "",

--- a/src/recipes/lentil-galette.json
+++ b/src/recipes/lentil-galette.json
@@ -1,6 +1,6 @@
 {
   "title": "Lentil galette",
-  "dateCreated": "2023-10-12",
+  "date": "2023-10-12",
   "dataTag": ["side"],
   "intro": "",
   "duration": "150",

--- a/src/recipes/miso-butter.json
+++ b/src/recipes/miso-butter.json
@@ -1,6 +1,6 @@
 {
   "title": "Miso butter",
-  "dateCreated": "2023-10-12",
+  "date": "2023-10-12",
   "dataTag": ["side"],
   "intro": "",
   "duration": "10",

--- a/src/recipes/orange-loaf-cake.json
+++ b/src/recipes/orange-loaf-cake.json
@@ -1,6 +1,6 @@
 {
   "title": "Orange loaf cake",
-  "dateCreated": "2022-02-10",
+  "date": "2022-02-10",
   "dataTag": ["dessert", "ahead", "fall", "winter"],
   "intro": "",
   "duration": "100",

--- a/src/recipes/overnight-oats.json
+++ b/src/recipes/overnight-oats.json
@@ -1,6 +1,6 @@
 {
   "title": "Overnight oats",
-  "dateCreated": "2022-11-22",
+  "date": "2022-11-22",
   "dataTag": ["main", "ahead"],
   "intro": "",
   "duration": "5",

--- a/src/recipes/pad-thai.json
+++ b/src/recipes/pad-thai.json
@@ -1,6 +1,6 @@
 {
   "title": "Pad thai",
-  "dateCreated": "2023-09-22",
+  "date": "2023-09-22",
   "dataTag": ["main"],
   "intro": "",
   "duration": "45",

--- a/src/recipes/pain-perdu.json
+++ b/src/recipes/pain-perdu.json
@@ -1,6 +1,6 @@
 {
   "title": "Pain perdu",
-  "dateCreated": "2022-11-09",
+  "date": "2022-11-09",
   "dataTag": ["dessert"],
   "intro": "",
   "duration": "45",

--- a/src/recipes/pasta-dough.json
+++ b/src/recipes/pasta-dough.json
@@ -1,6 +1,6 @@
 {
   "title": "Pasta dough",
-  "dateCreated": "2022-10-11",
+  "date": "2022-10-11",
   "dataTag": ["side"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/pasta-with-bean-sauce.json
+++ b/src/recipes/pasta-with-bean-sauce.json
@@ -1,6 +1,6 @@
 {
   "title": "Pasta with bean sauce",
-  "dateCreated": "2020-06-24",
+  "date": "2020-06-24",
   "dataTag": ["main"],
   "intro": "A pasta sauce made of beans only? Yep, it is apparently possible and surprisingly good.",
   "duration": "",

--- a/src/recipes/pate-brisee.json
+++ b/src/recipes/pate-brisee.json
@@ -1,6 +1,6 @@
 {
   "title": "Pâte brisée",
-  "dateCreated": "2023-06-30",
+  "date": "2023-06-30",
   "dataTag": ["side"],
   "intro": "",
   "duration": "75",

--- a/src/recipes/peach-ice-tea.json
+++ b/src/recipes/peach-ice-tea.json
@@ -1,6 +1,6 @@
 {
   "title": "Peach ice tea",
-  "dateCreated": "2023-08-08",
+  "date": "2023-08-08",
   "dataTag": ["side"],
   "intro": "",
   "duration": "300",

--- a/src/recipes/persian-rice-pilaf.json
+++ b/src/recipes/persian-rice-pilaf.json
@@ -1,6 +1,6 @@
 {
   "title": "Persian rice pilaf (sabzi polo)",
-  "dateCreated": "2022-11-09",
+  "date": "2022-11-09",
   "dataTag": ["side", "spring", "summer", "fall"],
   "intro": "One of my go-to recipes for when I have a lot of parsley I want to finish.",
   "duration": "120",

--- a/src/recipes/pie-dough.json
+++ b/src/recipes/pie-dough.json
@@ -1,6 +1,6 @@
 {
   "title": "Pie dough",
-  "dateCreated": "2021-01-21",
+  "date": "2021-01-21",
   "dataTag": ["side"],
   "intro": "",
   "duration": "",

--- a/src/recipes/polish-vegetarian-cabbage-rolls.json
+++ b/src/recipes/polish-vegetarian-cabbage-rolls.json
@@ -1,6 +1,6 @@
 {
   "title": "Polish vegetarian cabbage rolls",
-  "dateCreated": "2021-01-19",
+  "date": "2021-01-19",
   "dataTag": ["main", "fall", "winter", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/potato-gratin.json
+++ b/src/recipes/potato-gratin.json
@@ -1,6 +1,6 @@
 {
   "title": "Potato gratin",
-  "dateCreated": "2022-10-31",
+  "date": "2022-10-31",
   "dataTag": ["main"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/potato-soup.json
+++ b/src/recipes/potato-soup.json
@@ -1,6 +1,6 @@
 {
   "title": "Potato soup",
-  "dateCreated": "2023-03-01",
+  "date": "2023-03-01",
   "dataTag": ["main", "ahead", "fall", "winter"],
   "intro": "",
   "duration": "50",

--- a/src/recipes/puff-pastry.json
+++ b/src/recipes/puff-pastry.json
@@ -1,6 +1,6 @@
 {
   "title": "Puff pastry",
-  "dateCreated": "2022-12-15",
+  "date": "2022-12-15",
   "dataTag": ["side"],
   "intro": "This puff pastry recipe doesn't result in as many layers as a store-bought dough, but it does the job with minimal effort.",
   "duration": "140",

--- a/src/recipes/recipe-layout.njk
+++ b/src/recipes/recipe-layout.njk
@@ -6,7 +6,7 @@ pagination:
 permalink: "recipes/{{ recipe.key }}/"
 eleventyComputed:
     title: "{{ recipe.title }}"
-    dateCreated: "{{ recipe.dateCreated }}"
+    date: "{{ recipe.date }}"
     duration: "{{ recipe.duration }}"
     directory: "recipes"
 ---

--- a/src/recipes/rice-pilaf.json
+++ b/src/recipes/rice-pilaf.json
@@ -1,6 +1,6 @@
 {
   "title": "Rice pilaf",
-  "dateCreated": "2023-02-03",
+  "date": "2023-02-03",
   "dataTag": ["main"],
   "intro": "",
   "duration": "40",

--- a/src/recipes/roasted-vegetables.json
+++ b/src/recipes/roasted-vegetables.json
@@ -1,6 +1,6 @@
 {
   "title": "Roasted vegetables",
-  "dateCreated": "2022-11-22",
+  "date": "2022-11-22",
   "dataTag": ["side", "ahead"],
   "intro": "",
   "duration": "45",

--- a/src/recipes/shortbread.json
+++ b/src/recipes/shortbread.json
@@ -1,6 +1,6 @@
 {
   "title": "Shortbread",
-  "dateCreated": "2021-02-14",
+  "date": "2021-02-14",
   "dataTag": ["dessert"],
   "intro": "",
   "duration": "",

--- a/src/recipes/slovenian-sauerkraut-stew.json
+++ b/src/recipes/slovenian-sauerkraut-stew.json
@@ -1,6 +1,6 @@
 {
   "title": "Slovenian Sauerkraut stew",
-  "dateCreated": "2022-04-03",
+  "date": "2022-04-03",
   "dataTag": ["main", "fall", "winter", "ahead"],
   "intro": "",
   "duration": "",

--- a/src/recipes/solid-deodorant.json
+++ b/src/recipes/solid-deodorant.json
@@ -1,6 +1,6 @@
 {
   "title": "Solid deodorant",
-  "dateCreated": "2021-04-11",
+  "date": "2021-04-11",
   "dataTag": ["diy"],
   "intro": "This is the DIY deodorant recipe I have been using for many years now. Simple and effective.",
   "duration": "",

--- a/src/recipes/solid-shampoo.json
+++ b/src/recipes/solid-shampoo.json
@@ -1,6 +1,6 @@
 {
   "title": "Solid shampoo",
-  "dateCreated": "2023-10-15",
+  "date": "2023-10-15",
   "dataTag": ["diy"],
   "intro": "",
   "duration": "30",

--- a/src/recipes/sourdough-bagels.json
+++ b/src/recipes/sourdough-bagels.json
@@ -1,6 +1,6 @@
 {
   "title": "Sourdough bagels",
-  "dateCreated": "2021-01-22",
+  "date": "2021-01-22",
   "dataTag": ["side"],
   "intro": "",
   "duration": "",

--- a/src/recipes/sourdough-burger-buns.json
+++ b/src/recipes/sourdough-burger-buns.json
@@ -1,6 +1,6 @@
 {
   "title": "Sourdough burger buns",
-  "dateCreated": "2021-01-22",
+  "date": "2021-01-22",
   "dataTag": ["side"],
   "intro": "",
   "duration": "",

--- a/src/recipes/sourdough-naan.json
+++ b/src/recipes/sourdough-naan.json
@@ -1,6 +1,6 @@
 {
   "title": "Sourdough naan",
-  "dateCreated": "2023-09-18",
+  "date": "2023-09-18",
   "dataTag": ["side"],
   "intro": "",
   "duration": "220",

--- a/src/recipes/stuffed-vine-leaves.json
+++ b/src/recipes/stuffed-vine-leaves.json
@@ -1,6 +1,6 @@
 {
   "title": "Stuffed vine leaves",
-  "dateCreated": "2023-07-31",
+  "date": "2023-07-31",
   "dataTag": ["side", "ahead", "preserve"],
   "intro": "France's recipe, perfect for quick out-of-the-freezer starters.",
   "duration": "120",

--- a/src/recipes/sushi-gimbap.json
+++ b/src/recipes/sushi-gimbap.json
@@ -1,6 +1,6 @@
 {
   "title": "Sushi / gimbap",
-  "dateCreated": "2024-05-12",
+  "date": "2024-05-12",
   "dataTag": ["main", "spring", "fall", "winter", "summer"],
   "intro": "On fait une pause de deux mois à Hanoi lors de notre voyage de l'Europe à l'Asie. On y loue un appart pas cher avec une toute petite cuisine à peine fonctionnelle. Que peut-on préparer avec un minimum de 'cuisine' nécessaire et avec des ingrédients disponibles ? Je me lance dans des rouleaux inspirés des sushis japonais et gimbaps coréens.",
   "duration": "60",

--- a/src/recipes/tarte-tatin-with-summer-veggies.json
+++ b/src/recipes/tarte-tatin-with-summer-veggies.json
@@ -1,6 +1,6 @@
 {
   "title": "Tarte tatin with summer veggies",
-  "dateCreated": "2023-07-24",
+  "date": "2023-07-24",
   "dataTag": ["main", "ahead"],
   "intro": "",
   "duration": "80",

--- a/src/recipes/tarte-tatin.json
+++ b/src/recipes/tarte-tatin.json
@@ -1,6 +1,6 @@
 {
   "title": "Tarte tatin",
-  "dateCreated": "2023-09-13",
+  "date": "2023-09-13",
   "dataTag": ["dessert", "autumn"],
   "intro": "",
   "duration": "60",

--- a/src/recipes/thai-red-curry-paste.json
+++ b/src/recipes/thai-red-curry-paste.json
@@ -1,6 +1,6 @@
 {
   "title": "Thai red curry paste (prig gang ped)",
-  "dateCreated": "2022-07-10",
+  "date": "2022-07-10",
   "dataTag": ["main"],
   "intro": "",
   "duration": "80",

--- a/src/recipes/turnip-with-honey-and-zaatar.json
+++ b/src/recipes/turnip-with-honey-and-zaatar.json
@@ -1,6 +1,6 @@
 {
   "title": "Turnips with honey and zaatar",
-  "dateCreated": "2023-03-06",
+  "date": "2023-03-06",
   "dataTag": ["side", "ahead", "winter"],
   "intro": "France's recipe: great as a side, can be eaten hot or cold.",
   "duration": "50",

--- a/src/recipes/vegetarian-gravy-upgraded.json
+++ b/src/recipes/vegetarian-gravy-upgraded.json
@@ -1,6 +1,6 @@
 {
   "title": "Vegetarian gravy (upgraded version)",
-  "dateCreated": "2022-12-06",
+  "date": "2022-12-06",
   "dataTag": ["side"],
   "intro": "",
   "duration": "30",

--- a/src/recipes/vegetarian-gravy.json
+++ b/src/recipes/vegetarian-gravy.json
@@ -1,6 +1,6 @@
 {
   "title": "Vegetarian gravy",
-  "dateCreated": "2022-02-10",
+  "date": "2022-02-10",
   "dataTag": ["side"],
   "intro": "",
   "duration": "15",

--- a/src/recipes/veggie-loaf.json
+++ b/src/recipes/veggie-loaf.json
@@ -1,6 +1,6 @@
 {
   "title": "Veggie loaf",
-  "dateCreated": "2022-11-20",
+  "date": "2022-11-20",
   "dataTag": ["main"],
   "intro": "Recette de Souad, toute simple et goûtue.",
   "duration": "75",

--- a/src/recipes/vietnamese-chao-ga.json
+++ b/src/recipes/vietnamese-chao-ga.json
@@ -1,6 +1,6 @@
 {
   "title": "Vietnamese cháo gà",
-  "dateCreated": "2022-11-30",
+  "date": "2022-11-30",
   "dataTag": ["main", "ahead", "fall", "winter"],
   "intro": "Reminescent of childhood memories. Chao was my mother go-to recipe whenever someone in the family would get sick.",
   "duration": "120",

--- a/src/recipes/vietnamese-do-chua.json
+++ b/src/recipes/vietnamese-do-chua.json
@@ -1,6 +1,6 @@
 {
   "title": "Vietnamese đồ chua",
-  "dateCreated": "2023-02-25",
+  "date": "2023-02-25",
   "dataTag": ["side", "ahead", "preserve"],
   "intro": "",
   "duration": "20",

--- a/src/recipes/watermelon-salad.json
+++ b/src/recipes/watermelon-salad.json
@@ -1,6 +1,6 @@
 {
   "title": "Watermelon salad",
-  "dateCreated": "2023-09-14",
+  "date": "2023-09-14",
   "dataTag": ["side", "summer"],
   "intro": "A refreshing sweet and savory salad for hot summer days.",
   "duration": "20",

--- a/src/recipes/whole-roasted-cauliflower.json
+++ b/src/recipes/whole-roasted-cauliflower.json
@@ -1,6 +1,6 @@
 {
   "title": "Whole roasted cauliflower",
-  "dateCreated": "2022-10-06",
+  "date": "2022-10-06",
   "dataTag": ["main", "spring", "summer"],
   "intro": "",
   "duration": "100",

--- a/src/recipes/zucchini-soup.json
+++ b/src/recipes/zucchini-soup.json
@@ -1,6 +1,6 @@
 {
   "title": "Zucchini soup",
-  "dateCreated": "2023-07-06",
+  "date": "2023-07-06",
   "dataTag": ["main", "summer"],
   "intro": "",
   "duration": "30",


### PR DESCRIPTION
`date` metadata is by default by 11ty to sort posts. It is also stored in a more accessible manner than a custom frontmatter data. I'd rather use `date` to simplify some of the code and not go against the grain. 